### PR TITLE
Lint data-raw in generated atlas packages

### DIFF
--- a/inst/templates/atlas-fallback/DESCRIPTION
+++ b/inst/templates/atlas-fallback/DESCRIPTION
@@ -30,3 +30,8 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Config/testthat/edition: 3
 Config/Needs/website: ggsegverse/ggseg.docs
+Config/Needs/lint:
+    dplyr,
+    future,
+    progressr,
+    ggsegverse/ggseg.extra

--- a/inst/templates/atlas-fallback/dot-lintr
+++ b/inst/templates/atlas-fallback/dot-lintr
@@ -1,1 +1,1 @@
-exclusions: list("data-raw")
+exclusions: list("data-raw/create-atlas.R" = list(commented_code_linter = Inf))

--- a/tests/testthat/test-atlas_repo.R
+++ b/tests/testthat/test-atlas_repo.R
@@ -179,6 +179,29 @@ describe("setup_atlas_repo template files", {
     }
   })
 
+  it("excludes only commented_code_linter, and only from create-atlas.R", {
+    # A blanket data-raw exclusion would also silence object_usage_linter,
+    # which is the one worth keeping there. create-atlas.R is a menu of
+    # commented-out example invocations, so only that linter misfires.
+    config <- readLines(file.path(tmp, ".lintr"), warn = FALSE)
+
+    expect_match(config, "create-atlas\\.R", all = FALSE)
+    expect_match(config, "commented_code_linter", all = FALSE)
+    expect_false(any(grepl("object_usage_linter", config)))
+  })
+
+  it("declares the data-raw dependencies for the lint job", {
+    # Without these, object_usage_linter cannot resolve what create-atlas.R
+    # loads and reports every call through them as an undefined global.
+    needs <- read.dcf(file.path(tmp, "DESCRIPTION"))[1, "Config/Needs/lint"]
+    declared <- trimws(strsplit(needs, ",")[[1]])
+
+    expect_setequal(
+      declared,
+      c("dplyr", "future", "progressr", "ggsegverse/ggseg.extra")
+    )
+  })
+
   it("adds the shared GitHub Actions workflows", {
     written <- list.files(file.path(tmp, ".github", "workflows"))
 

--- a/tests/testthat/test-atlas_repo.R
+++ b/tests/testthat/test-atlas_repo.R
@@ -187,14 +187,14 @@ describe("setup_atlas_repo template files", {
 
     expect_match(config, "create-atlas\\.R", all = FALSE)
     expect_match(config, "commented_code_linter", all = FALSE)
-    expect_false(any(grepl("object_usage_linter", config)))
+    expect_false(any(grepl("object_usage_linter", config, fixed = TRUE)))
   })
 
   it("declares the data-raw dependencies for the lint job", {
     # Without these, object_usage_linter cannot resolve what create-atlas.R
     # loads and reports every call through them as an undefined global.
     needs <- read.dcf(file.path(tmp, "DESCRIPTION"))[1, "Config/Needs/lint"]
-    declared <- trimws(strsplit(needs, ",")[[1]])
+    declared <- trimws(strsplit(needs, ",", fixed = TRUE)[[1]])
 
     expect_setequal(
       declared,


### PR DESCRIPTION
## Summary

The atlas scaffold's `.lintr` excluded `data-raw` wholesale, so every generated atlas package skipped linting `data-raw/create-atlas.R` — the one file in a new atlas package that anyone actually edits. This narrows the exclusion to the single linter that genuinely misfires there, and leaves the rest live.

Two separate things were hiding behind the blanket exclusion:

**1. `object_usage_linter` can't resolve what the script loads.** `create-atlas.R` loads dplyr, future, progressr and ggseg.extra. None is a runtime dependency of a generated package, so none is installed on the lint runner. Undeclared, `library()` yields "could not find exported symbols" and every call through them is reported as an undefined global — real functions, flagged as missing. Fixed by adding `Config/Needs/lint` to the scaffold `DESCRIPTION`, which `setup-r-dependencies` reads for that job. `Imports`/`Suggests` unchanged, so a generated package still installs without any of them.

**2. `commented_code_linter` fires 59 times** on `create-atlas.R`, which is a menu of commented-out example invocations — one per atlas type — that the user uncomments. That's the file working as intended. So `dot-lintr` now disables that one linter for that one file:

```
exclusions: list("data-raw/create-atlas.R" = list(commented_code_linter = Inf))
```

Per-*file* exclusion matters here: a directory exclusion would also silence `object_usage_linter` on `data-raw`, which is the one worth keeping.

## Verification

Rendered the template into a package and linted it the way `template-check` does:

| Config | Lints |
|---|---|
| No `.lintr` | 60 (59 `commented_code_linter`, 1 `object_usage_linter`) |
| Narrowed `.lintr` | 1 |
| Narrowed `.lintr`, after `R CMD INSTALL` | **0** |

That last row is the CI condition — the workflow already installs the generated package before linting, so `object_usage_linter` can resolve the atlas object out of the namespace.

## Merge order

Paired with the matching change in `ggsegverse/ggseg-atlas-template`. That repo's `fallback-in-sync` job diffs its scaffold against this copy on `main`, comparing `DESCRIPTION` and `.lintr`/`dot-lintr` among others.

**This PR must merge first.** Until it does, the template PR's `fallback-in-sync` job will fail — expected, and resolves on merge here.

## Test Plan

- `devtools::test()` — 2290 pass, 0 fail.
- `lintr::lint_package()` — 0 lints.
- `test-atlas_repo.R` gains two tests: one asserting `Config/Needs/lint` names exactly the four packages `create-atlas.R` loads (stops the declaration drifting from the script), one asserting the `.lintr` excludes `commented_code_linter` for `create-atlas.R` and does *not* mention `object_usage_linter` (stops the exclusion quietly widening back out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)