### PR TITLE
Fix the brain silhouette: skip the punch when already hollow, consume the operand when not

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,19 @@ rebuild.
   simplifying a rounded outline replaces its curves with straight chords,
   putting the stair-step back.
 
+- `aseg_context()` no longer leaves two brain silhouettes behind. The
+  white-matter punch subtracts the white matter from the silhouette and
+  writes the result to `cortex`, but `atlas_region_op()` only replaces rows
+  already named that - so the operand it was derived from, which the
+  pipelines call `cortex_`, survived and drew behind the ribbon as a second
+  full-brain outline. One character apart, which is why it went unnoticed.
+
+  It is the largest label in a subcortical atlas, so the duplicate was also
+  the single biggest thing in the file: dropping it takes ggsegHO's `ho_sub`
+  silhouette from 26,336 vertices to 6,470. Every atlas built through
+  `aseg_context()` is affected, including the bundled `aseg`, and all of
+  them need rebuilding to benefit.
+
 ## Minor improvements and fixes
 
 - Test `describe()` calls are namespace-qualified.

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,18 +36,29 @@ rebuild.
   simplifying a rounded outline replaces its curves with straight chords,
   putting the stair-step back.
 
-- `aseg_context()` no longer leaves two brain silhouettes behind. The
-  white-matter punch subtracts the white matter from the silhouette and
-  writes the result to `cortex`, but `atlas_region_op()` only replaces rows
-  already named that - so the operand it was derived from, which the
-  pipelines call `cortex_`, survived and drew behind the ribbon as a second
-  full-brain outline. One character apart, which is why it went unnoticed.
+- `aseg_context()` no longer leaves two brain silhouettes behind, and no
+  longer punches a silhouette that does not need it.
 
-  It is the largest label in a subcortical atlas, so the duplicate was also
-  the single biggest thing in the file: dropping it takes ggsegHO's `ho_sub`
-  silhouette from 26,336 vertices to 6,470. Every atlas built through
-  `aseg_context()` is affected, including the bundled `aseg`, and all of
-  them need rebuilding to benefit.
+  The white-matter punch writes its result to `cortex`, but
+  `atlas_region_op()` only replaces rows already named that - so the operand
+  it was derived from, which the pipelines call `cortex_`, survived and drew
+  behind the ribbon as a second full-brain outline. One character apart,
+  which is why it went unnoticed. The punch now consumes its operand.
+
+  The punch is also skipped when the silhouette is already hollow. It exists
+  to hollow out a solid outline; snapshot pipelines that trace the
+  grey-matter ribbon hand over one that is already hollow, and differencing
+  the white matter out of that removes about a quarter of the mantle,
+  because the white matter abuts the ribbon rather than sitting inside it.
+  Whole sections of outline went missing. Interior rings tell the two apart:
+  a solid outline has none, a ribbon has hundreds.
+
+  The silhouette is the largest label in a subcortical atlas, so this is
+  also the biggest single thing in the file. Together with per-label
+  simplification it takes the `ho_sub` atlas in ggsegHO from 89,657 vertices to
+  34,103.
+  Every atlas built through `aseg_context()` is affected, the bundled `aseg`
+  included, and each needs rebuilding to benefit.
 
 ## Minor improvements and fixes
 

--- a/R/subcortical_builders.R
+++ b/R/subcortical_builders.R
@@ -238,20 +238,37 @@ aseg_context <- function(
 #' Subtract the cerebral white matter from the brain silhouette
 #' @noRd
 aseg_punch_white_matter <- function(atlas, cortex, white_matter, sf_labels) {
-  if (any(grepl(cortex, sf_labels)) && any(grepl(white_matter, sf_labels))) {
-    atlas <- atlas_region_op(
-      atlas,
-      x = cortex,
-      y = white_matter,
-      action = "difference",
-      into = "cortex"
-    )
-  } else {
+  if (!(any(grepl(cortex, sf_labels)) && any(grepl(white_matter, sf_labels)))) {
     cli::cli_alert_info(
       "Skipping white-matter punch: {.val {cortex}} and
       {.val {white_matter}} not both present."
     )
+    return(atlas)
   }
+
+  atlas <- atlas_region_op(
+    atlas,
+    x = cortex,
+    y = white_matter,
+    action = "difference",
+    into = "cortex"
+  )
+
+  # atlas_region_op() keeps its operands - it only replaces rows already
+  # named `into` - so the un-punched silhouette this was derived from is
+  # still there, drawn behind the ribbon as a second full-brain outline.
+  # On a subcortical atlas it is the single largest label, so leaving it
+  # roughly doubles the silhouette's cost for something nobody can see
+  # except as a doubled edge.
+  spent <- setdiff(unique(sf_labels[grepl(cortex, sf_labels)]), "cortex")
+  if (length(spent)) {
+    atlas <- atlas_region_remove(
+      atlas,
+      paste0("^(", paste(rx_escape(spent), collapse = "|"), ")$"),
+      match_on = "label"
+    )
+  }
+
   atlas
 }
 

--- a/R/subcortical_builders.R
+++ b/R/subcortical_builders.R
@@ -246,6 +246,19 @@ aseg_punch_white_matter <- function(atlas, cortex, white_matter, sf_labels) {
     return(atlas)
   }
 
+  # The punch exists to hollow out a solid silhouette. Snapshot pipelines
+  # that trace the grey-matter ribbon directly hand us one that is already
+  # hollow, and punching that removes a quarter of the mantle - the white
+  # matter label abuts the ribbon, so the difference eats into it and leaves
+  # whole sections of outline missing. Interior rings are what tells the two
+  # apart: a solid outline has none, a ribbon has hundreds.
+  if (silhouette_is_hollow(atlas, cortex)) {
+    cli::cli_alert_info(
+      "Skipping white-matter punch: {.val {cortex}} is already hollow."
+    )
+    return(atlas)
+  }
+
   atlas <- atlas_region_op(
     atlas,
     x = cortex,
@@ -271,6 +284,41 @@ aseg_punch_white_matter <- function(atlas, cortex, white_matter, sf_labels) {
 
   atlas
 }
+
+#' Does the silhouette already have holes punched in it?
+#'
+#' Counts interior rings across the cortex geometry. A solid outline traced
+#' round the outside of the brain has none; a grey-matter ribbon has one per
+#' enclosed sulcus or ventricle, so in practice hundreds.
+#' @noRd
+silhouette_is_hollow <- function(atlas, cortex) {
+  if (is.null(ggseg.formats::atlas_geom(atlas))) {
+    return(FALSE)
+  }
+
+  # A pipeline atlas arrives as polygons; interior rings are an sf notion,
+  # so ask sf.
+  geom <- ggseg.formats::atlas_geom(ggseg.formats::as_sf_atlas(atlas))
+  rows <- geom[grepl(cortex, geom$label), , drop = FALSE]
+  if (nrow(rows) == 0) {
+    return(FALSE)
+  }
+
+  rings <- vapply(
+    sf::st_geometry(rows),
+    function(g) {
+      if (inherits(g, "MULTIPOLYGON")) {
+        sum(vapply(g, function(part) length(part) - 1L, integer(1)))
+      } else {
+        length(g) - 1L
+      }
+    },
+    integer(1)
+  )
+
+  sum(rings) > 0L
+}
+
 
 #' Demote every core region not matched by `focus` to grey context
 #' @noRd

--- a/R/subcortical_builders.R
+++ b/R/subcortical_builders.R
@@ -273,7 +273,7 @@ aseg_punch_white_matter <- function(atlas, cortex, white_matter, sf_labels) {
   # On a subcortical atlas it is the single largest label, so leaving it
   # roughly doubles the silhouette's cost for something nobody can see
   # except as a doubled edge.
-  spent <- setdiff(unique(sf_labels[grepl(cortex, sf_labels)]), "cortex")
+  spent <- setdiff(unique(grep(cortex, sf_labels, value = TRUE)), "cortex")
   if (length(spent)) {
     atlas <- atlas_region_remove(
       atlas,

--- a/tests/testthat/test-subcortical_builders.R
+++ b/tests/testthat/test-subcortical_builders.R
@@ -11,6 +11,10 @@ mk_square <- function(x0, y0, s = 2) {
 # Minimal subcortical atlas: a focus region whose name is a superstring of a
 # context region (hypothalamus / Thalamus), a hidden white-matter label, and a
 # cortex silhouette. A second view carries only context.
+# An interior ring must wind opposite to its shell for sf to read it as a
+# hole rather than an invalid self-intersection.
+rev_ring <- function(m) m[rev(seq_len(nrow(m))), , drop = FALSE]
+
 make_test_atlas <- function() {
   labels <- c(
     "L_hypothalamus_anterior_inferior",
@@ -249,6 +253,35 @@ testthat::describe("aseg_context input validation and white-matter punch", {
     )
 
     expect_identical(unique(silhouettes), "cortex")
+  })
+
+  it("skips the punch when the silhouette is already hollow", {
+    # Snapshot pipelines that trace the grey-matter ribbon hand us a
+    # silhouette that is already hollow. Punching that removes a quarter of
+    # the mantle, because the white matter abuts the ribbon rather than
+    # sitting inside it - whole sections of outline go missing.
+    atlas <- make_test_atlas()
+    geom <- ggseg.formats::atlas_geom(atlas)
+    geom$label[geom$label == "cortex"] <- "cortex_"
+
+    ring <- which(geom$label == "cortex_")[1]
+    outer <- sf::st_coordinates(geom$geometry[[ring]])[, c("X", "Y")]
+    hole <- mk_square(0, 0, 4)
+    geom$geometry[[ring]] <- sf::st_polygon(list(
+      outer,
+      rev_ring(sf::st_coordinates(hole)[, c("X", "Y")])
+    ))
+    atlas$data$geom <- geom
+
+    a <- aseg_context(
+      atlas,
+      focus = "hypothalamus",
+      punch_white_matter = TRUE
+    )
+
+    expect_true(
+      "cortex_" %in% ggseg.formats::atlas_geom(a)$label
+    )
   })
 })
 

--- a/tests/testthat/test-subcortical_builders.R
+++ b/tests/testthat/test-subcortical_builders.R
@@ -224,6 +224,32 @@ testthat::describe("aseg_context input validation and white-matter punch", {
       "Left-Cerebral-White-Matter" %in% ggseg.formats::atlas_geom(a)$label
     )
   })
+
+  it("leaves one silhouette, not the punched one plus its operand", {
+    # The pipelines name their silhouette `cortex_`, not `cortex`. That one
+    # character is the whole bug: atlas_region_op() writes the punched
+    # result to `cortex` and only drops rows already named that, so an
+    # operand called `cortex_` survives and draws behind the ribbon as a
+    # second full-brain outline - the single largest label in a subcortical
+    # atlas.
+    atlas <- make_test_atlas()
+    geom <- ggseg.formats::atlas_geom(atlas)
+    geom$label[geom$label == "cortex"] <- "cortex_"
+    atlas$data$geom <- geom
+
+    a <- aseg_context(
+      atlas,
+      focus = "hypothalamus",
+      punch_white_matter = TRUE
+    )
+    silhouettes <- grep(
+      "^cortex",
+      ggseg.formats::atlas_geom(a)$label,
+      value = TRUE
+    )
+
+    expect_identical(unique(silhouettes), "cortex")
+  })
 })
 
 testthat::describe("aseg_punch_white_matter", {


### PR DESCRIPTION
## Summary

Two bugs in `aseg_context()`'s white-matter punch, both of which damage the
brain silhouette — the largest label in a subcortical atlas.

### 1. The punch is wrong when the silhouette is already hollow

The punch differences the cerebral white matter out of the silhouette. That
is correct for a **solid** outline — which is what the `aseg` build produces,
and the punch is what hollows it.

It is wrong for one that is **already a ribbon**. The snapshot pipelines that
trace the grey-matter ribbon hand over a silhouette with hundreds of interior
rings; there the white matter *abuts* the mantle rather than sitting inside
it, overlapping 24.7% of it. Differencing it out eats a quarter of the mantle
and leaves whole sections of outline missing.

Interior rings separate the two cleanly:

| atlas | silhouette | interior rings | punch |
|---|---|---|---|
| `aseg` | solid | 0 | correct — it does the hollowing |
| ggsegHO `ho_sub` | already a ribbon | 312 | destructive — skipped now |
| ggsegHO `ho2_sub` | already a ribbon | 249 | destructive — skipped now |

### 2. When it does punch, it leaves its operand behind

`atlas_region_op()` writes the result to `cortex` and only replaces rows
already named that — so the operand, which the pipelines call `cortex_`,
survived and drew behind the ribbon as a second full-brain outline. One
character apart, which is why it went unnoticed. It now consumes it.

### Effect

`ho_sub`: **89,657 → 34,103 vertices (−62%)**, one silhouette label, complete
continuous outline with the gyri intact.

**Every atlas built through `aseg_context()` is affected** and needs a rebuild
to benefit: ggsegHO (`make_ho.R`, `make_ho2_subcortical.R`), ggsegBrainnetome
(`make_subcortical.R`), and the bundled `aseg` in ggseg.formats.

## Why the existing test missed it

`make_test_atlas()` names its silhouette `cortex` — exactly `into` — so the
pre-existing `label != into` filter removed it for the wrong reason, and its
squares have no interior rings so the hollow path was never taken. The two new
tests cover both branches and were each verified to fail against the unfixed
source.

## Test plan

- `devtools::test()` — 2305 passing, 0 failures
- Both new tests confirmed failing on the unfixed source (stashed `R/` only)
- `lintr::lint_package()` — 0 lints; `spelling::spell_check_package()` — clean
- `R CMD check --as-cran` — 0 errors, 0 warnings, 1 note (dev version string)
- Rebuilt `ho_sub` end to end and rendered: complete mantle, no missing
  sections, single `cortex_` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)