### PR TITLE
Install freesurfer from upstream and enforce its minimum version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -15,5 +15,5 @@ jobs:
     with:
       extra-packages: |
         any::rcmdcheck
-        github::drmowinckels/freesurfer@refactor
+        github::muschellij2/freesurfer
       install-spatial-deps: true

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -17,4 +17,4 @@ jobs:
     secrets: inherit
     with:
       install-spatial-deps: true
-      extra-packages: github::drmowinckels/freesurfer@refactor
+      extra-packages: github::muschellij2/freesurfer

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -23,5 +23,5 @@ jobs:
       extra-packages: |
         any::pkgdown
         any::quarto
-        github::drmowinckels/freesurfer@refactor
+        github::muschellij2/freesurfer
         local::.

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -18,4 +18,4 @@ jobs:
     secrets: inherit
     with:
       install-spatial-deps: true
-      extra-packages: any::covr, github::drmowinckels/freesurfer@refactor
+      extra-packages: any::covr, github::muschellij2/freesurfer

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,6 +78,8 @@ Suggests:
     quarto,
     withr,
     princurve
+Remotes:
+    muschellij2/freesurfer
 VignetteBuilder:
     knitr,
     quarto

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg.extra
 Title: Create Brain Atlases for the 'ggsegverse' Plotting Ecosystem
-Version: 1.9.9.9016
+Version: 1.9.9.9017
 Authors@R: c(
     person(
         given = "Athanasia Mo",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Suggests:
     base64enc,
     chromote,
     ciftiTools,
-    freesurfer,
+    freesurfer (>= 1.8.1.902),
     freesurferformats,
     ggplot2,
     gifti,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 - The README and CI now install freesurfer from `muschellij2/freesurfer`:
   the refactor it needed has been merged upstream, so the
   `drmowinckels/freesurfer@refactor` fork is no longer required (#72, #98).
+  DESCRIPTION declares `Remotes: muschellij2/freesurfer`, so `pak` and
+  `remotes` resolve the required version without extra steps.
 
 - freesurfer is now required at `>= 1.8.1.902`. The CRAN release lacks
   `fs_sitrep()` and `fs_cmd(validate_inputs = )`, so an older install used to

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@
   the refactor it needed has been merged upstream, so the
   `drmowinckels/freesurfer@refactor` fork is no longer required (#72, #98).
 
+- freesurfer is now required at `>= 1.8.1.902`. The CRAN release lacks
+  `fs_sitrep()` and `fs_cmd(validate_inputs = )`, so an older install used to
+  pass the installed-check and then fail mid-pipeline. Accepting the install
+  prompt now installs from the ggsegverse r-universe instead of CRAN, whose
+  release could never satisfy the check. `setup_sitrep()` reports an outdated
+  freesurfer as missing and points at `muschellij2/freesurfer`.
+
 # ggseg.extra 1.9.9.9016
 
 ## Post-creation geometry

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ggseg.extra 1.9.9.9017
+
+- The README and CI now install freesurfer from `muschellij2/freesurfer`:
+  the refactor it needed has been merged upstream, so the
+  `drmowinckels/freesurfer@refactor` fork is no longer required (#72, #98).
+
 # ggseg.extra 1.9.9.9016
 
 ## Post-creation geometry

--- a/R/freesurfer.R
+++ b/R/freesurfer.R
@@ -79,6 +79,19 @@ mri_surf2surf_rereg <- function(
   run_cmd(cmd, verbose = verbose)
 }
 
+# The CRAN release lacks what the pipelines use (`fs_sitrep()`,
+# `fs_cmd(validate_inputs = )`), so a bare presence check passes on it and the
+# pipeline fails later. CRAN is also why installs go through r-universe.
+#' @noRd
+freesurfer_min_version <- function() {
+  "1.8.1.902"
+}
+
+#' @noRd
+freesurfer_repos <- function() {
+  c(ggsegverse = "https://ggsegverse.r-universe.dev", getOption("repos"))
+}
+
 #' Check if FS can be run
 #' @param abort logical. If function should error
 #'     if Freesurfer is not installed. Defaults to FALSE.
@@ -86,7 +99,14 @@ mri_surf2surf_rereg <- function(
 #' @keywords internal
 #' @noRd
 check_fs <- function(abort = FALSE) {
-  rlang::check_installed("freesurfer", reason = "to interact with FreeSurfer")
+  rlang::check_installed(
+    "freesurfer",
+    version = freesurfer_min_version(),
+    reason = "to interact with FreeSurfer",
+    action = function(...) {
+      utils::install.packages("freesurfer", repos = freesurfer_repos())
+    }
+  )
   x <- freesurfer::have_fs()
 
   if (!x) {

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -43,20 +43,22 @@ setup_sitrep <- function(detail = c("simple", "minimal", "full")) {
 
 
 check_freesurfer <- function(detail = "simple") {
-  if (!rlang::is_installed("freesurfer")) {
+  min_version <- freesurfer_min_version()
+  if (!rlang::is_installed("freesurfer", version = min_version)) {
     if (detail != "minimal") {
-      cli::cli_alert_danger("freesurfer R package not installed")
+      cli::cli_alert_danger(
+        "freesurfer R package (>= {min_version}) not installed"
+      )
       if (detail == "full") {
-        cli::cli_bullets(c(
-          "i" = 'Install with: {.code install.packages("freesurfer")}'
-        ))
+        install_hint <- 'remotes::install_github("muschellij2/freesurfer")'
+        cli::cli_bullets(c("i" = "Install with: {.code {install_hint}}"))
       }
     }
     return(list(available = FALSE))
   }
   has_fs <- freesurfer::have_fs()
 
-  if (detail == "full" && has_fs_sitrep()) {
+  if (detail == "full") {
     freesurfer::fs_sitrep()
   } else if (detail != "minimal") {
     if (has_fs) {
@@ -67,15 +69,6 @@ check_freesurfer <- function(detail = "simple") {
   }
 
   list(available = has_fs)
-}
-
-
-# `fs_sitrep()` is only exported by newer `freesurfer` versions; guard so the
-# diagnostic degrades gracefully on older/CRAN installs rather than aborting.
-# `check_freesurfer()` only reaches here once `freesurfer` is installed.
-#' @noRd
-has_fs_sitrep <- function() {
-  "fs_sitrep" %in% getNamespaceExports("freesurfer")
 }
 
 
@@ -124,7 +117,11 @@ check_other_system_deps <- function(detail = "simple") {
 check_fsaverage <- function(detail = "simple") {
   results <- list()
 
-  subj_dir <- if (rlang::is_installed("freesurfer")) {
+  has_freesurfer <- rlang::is_installed(
+    "freesurfer",
+    version = freesurfer_min_version()
+  )
+  subj_dir <- if (has_freesurfer) {
     tryCatch(freesurfer::fs_subj_dir(), error = function(e) "")
   } else {
     ""

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -50,8 +50,12 @@ check_freesurfer <- function(detail = "simple") {
         "freesurfer R package (>= {min_version}) not installed"
       )
       if (detail == "full") {
-        install_hint <- 'remotes::install_github("muschellij2/freesurfer")'
-        cli::cli_bullets(c("i" = "Install with: {.code {install_hint}}"))
+        cli::cli_bullets(c(
+          "i" = paste(
+            "Install with:",
+            '{.code remotes::install_github("muschellij2/freesurfer")}'
+          )
+        ))
       }
     }
     return(list(available = FALSE))

--- a/README.Rmd
+++ b/README.Rmd
@@ -50,11 +50,11 @@ remotes::install_github("ggsegverse/ggseg.extra")
 
 ### Development version of freesurfer
 
-The atlas creation functions require a development version of the freesurfer R package that is not yet on CRAN.
-Until the [PR is merged](https://github.com/muschellij2/freesurfer/pull/28), install from:
+The atlas creation functions require the development version of the freesurfer R package, which is not yet on CRAN.
+Install it from GitHub:
 
 ```{r, eval = FALSE}
-pak::pak("drmowinckels/freesurfer@refactor")
+pak::pak("muschellij2/freesurfer")
 ```
 
 ## Create custom atlases

--- a/README.md
+++ b/README.md
@@ -41,13 +41,11 @@ remotes::install_github("ggsegverse/ggseg.extra")
 
 ### Development version of freesurfer
 
-The atlas creation functions require a development version of the
-freesurfer R package that is not yet on CRAN. Until the [PR is
-merged](https://github.com/muschellij2/freesurfer/pull/28), install
-from:
+The atlas creation functions require the development version of the
+freesurfer R package, which is not yet on CRAN. Install it from GitHub:
 
 ``` r
-pak::pak("drmowinckels/freesurfer@refactor")
+pak::pak("muschellij2/freesurfer")
 ```
 
 ## Create custom atlases

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -37,7 +37,10 @@ skip_if_not_installed <- function(pkg) {
 # parallel native geometry stack there).
 skip_if_no_freesurfer <- function() {
   testthat::skip_on_os("windows")
-  testthat::skip_if_not_installed("freesurfer")
+  testthat::skip_if_not_installed(
+    "freesurfer",
+    minimum_version = freesurfer_min_version()
+  )
   # have_fs() only checks for the FreeSurfer directory; it returns TRUE even
   # when the binaries are not on PATH. Also require a representative binary to
   # be resolvable so tests that shell out (e.g. mri_info) skip instead of error.

--- a/tests/testthat/test-freesurfer.R
+++ b/tests/testthat/test-freesurfer.R
@@ -34,6 +34,38 @@ testthat::describe("check_fs", {
     result <- check_fs(abort = FALSE)
     expect_type(result, "logical")
   })
+
+  it("errors when freesurfer is older than the minimum version", {
+    local_mocked_bindings(freesurfer_min_version = function() "999.0.0")
+
+    expect_error(check_fs(), class = "rlib_error_package_not_found")
+  })
+})
+
+testthat::describe("freesurfer_repos", {
+  it("puts the ggsegverse r-universe ahead of the configured repos", {
+    withr::local_options(repos = c(CRAN = "https://cloud.r-project.org"))
+
+    expect_identical(
+      freesurfer_repos(),
+      c(
+        ggsegverse = "https://ggsegverse.r-universe.dev",
+        CRAN = "https://cloud.r-project.org"
+      )
+    )
+  })
+})
+
+testthat::describe("freesurfer_min_version", {
+  it("matches the Suggests constraint in DESCRIPTION", {
+    suggests <- utils::packageDescription("ggseg.extra", fields = "Suggests")
+
+    expect_match(
+      suggests,
+      paste0("freesurfer (>= ", freesurfer_min_version(), ")"),
+      fixed = TRUE
+    )
+  })
 })
 
 

--- a/tests/testthat/test-sitrep.R
+++ b/tests/testthat/test-sitrep.R
@@ -89,16 +89,6 @@ testthat::describe("check_freesurfer", {
     )
     expect_messages(check_freesurfer("simple"), "not configured")
   })
-
-  it("degrades gracefully in full mode when fs_sitrep is unavailable", {
-    local_mocked_bindings(
-      have_fs = function() TRUE,
-      .package = "freesurfer"
-    )
-    local_mocked_bindings(has_fs_sitrep = function() FALSE)
-    # older/CRAN `freesurfer` has no `fs_sitrep`: must fall back, not abort.
-    expect_messages(check_freesurfer("full"), "FreeSurfer")
-  })
 })
 
 
@@ -239,8 +229,22 @@ testthat::describe("check_freesurfer when freesurfer package absent", {
     )
     expect_messages(
       check_freesurfer("full"),
-      "install.packages"
+      "muschellij2"
     )
+  })
+
+  it("treats a freesurfer older than the minimum version as not installed", {
+    local_mocked_bindings(
+      is_installed = function(pkg, version = NULL) is.null(version),
+      .package = "rlang"
+    )
+    expect_messages(
+      {
+        result <- check_freesurfer("simple")
+      },
+      freesurfer_min_version()
+    )
+    expect_false(result$available)
   })
 })
 
@@ -258,6 +262,29 @@ testthat::describe("check_fsaverage additional branches", {
       "not found"
     )
     expect_false(result$fsaverage5)
+  })
+
+  it("does not query an outdated freesurfer for the subjects dir", {
+    local_mocked_bindings(
+      is_installed = function(pkg, version = NULL) is.null(version),
+      .package = "rlang"
+    )
+    .cap$queried <- FALSE
+    local_mocked_bindings(
+      fs_subj_dir = function() {
+        .cap$queried <- TRUE
+        ""
+      },
+      .package = "freesurfer"
+    )
+    expect_messages(
+      {
+        result <- check_fsaverage("simple")
+      },
+      "not found"
+    )
+    expect_false(result$fsaverage5)
+    expect_false(.cap$queried)
   })
 
   it("shows path in full detail when fsaverage5 exists", {


### PR DESCRIPTION
## Summary

The freesurfer refactor ggseg.extra relies on (muschellij2/freesurfer#19) was merged upstream on 2026-04-09. `drmowinckels/freesurfer@refactor` is now 0 commits ahead of and 3 behind `muschellij2/freesurfer` master, so pinning the fork installs an older copy of the same code.

**Install source**
- README install instructions now use `pak::pak("muschellij2/freesurfer")`.
- `R-CMD-check`, `code-quality`, `pkgdown` and `test-coverage` install `github::muschellij2/freesurfer`.

**Minimum version, enforced where freesurfer is checked**

The CRAN release (1.8.1) lacks `fs_sitrep()` and `fs_cmd(validate_inputs = )`, both verified against the CRAN tarball. It still passed every presence check, so pipelines failed partway through (e.g. #74).
- `DESCRIPTION` Suggests: `freesurfer (>= 1.8.1.902)`. A test keeps this in sync with the internal `freesurfer_min_version()`.
- `check_fs()` passes the minimum version. Its interactive install prompt installs from the ggsegverse r-universe, because CRAN can never satisfy the check.
- `setup_sitrep()` applies the same minimum in `check_freesurfer()` and `check_fsaverage()`. Its install hint is now `remotes::install_github("muschellij2/freesurfer")`, matching the file's other hints.
- Removed `has_fs_sitrep()` and its test. Every version at or above the minimum exports `fs_sitrep()`, so the guard could no longer be reached.
- `skip_if_no_freesurfer()` now skips on an outdated install instead of failing.

Dev version bumped to 1.9.9.9017, with a NEWS entry.

Companion: ggsegverse/ggsegverse.r-universe.dev#5 moves the r-universe freesurfer build from the fork to upstream.

Closes #72, closes #98.

## Review

- critical review, security review and simplify pass run before this update.
- Security: no findings at confidence ≥ 8.
- Simplify: took the dead-guard removal, the corrected rationale, the install-prompt source, the test-helper minimum and the `check_fsaverage()` consistency. Skipped replacing the one-line `freesurfer_min_version()` function with a plain constant: no real difference.

## Test Plan

- [x] Full local suite on R 4.6.1 with upstream freesurfer 1.8.1.902: 2314 pass, 0 fail, 0 warn, 0 skip
- [x] lintr (repo config) clean on changed files; `air format` applied
- [x] New tests: version floor aborts `check_fs()`; Suggests/constant sync; r-universe repos ordering; sitrep treats outdated freesurfer as missing; `check_fsaverage()` does not query an outdated freesurfer
- [ ] R-CMD-check (all platforms), test-coverage, code-quality, pkgdown green

🤖 Generated with [Claude Code](https://claude.com/claude-code)