### PR TITLE
Import only is_ggseg_atlas from ggseg.formats in the atlas template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg.extra
 Title: Create Brain Atlases for the 'ggsegverse' Plotting Ecosystem
-Version: 1.9.9.9018
+Version: 1.9.9.9019
 Authors@R: c(
     person(
         given = "Athanasia Mo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# ggseg.extra 1.9.9.9019
+
+- The bundled atlas-package template imports only `is_ggseg_atlas()` from
+  ggseg.formats instead of the whole package, so generated atlas packages
+  pass goodpractice's `no_import_package_as_a_whole` check. Mirrors
+  ggsegverse/ggseg-atlas-template#7.
+
 # ggseg.extra 1.9.9.9018
 
 - New `read_cifti_subcortical()` extracts the subcortical voxels of a CIFTI

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - The bundled atlas-package template imports only `is_ggseg_atlas()` from
   ggseg.formats instead of the whole package, so generated atlas packages
-  pass goodpractice's `no_import_package_as_a_whole` check. Mirrors
+  pass the `goodpractice` check `no_import_package_as_a_whole`. Mirrors
   ggsegverse/ggseg-atlas-template#7.
 
 # ggseg.extra 1.9.9.9018

--- a/inst/templates/atlas-fallback/R/PKGNAME-package.R
+++ b/inst/templates/atlas-fallback/R/PKGNAME-package.R
@@ -1,3 +1,3 @@
 #' @keywords internal
-#' @import ggseg.formats
+#' @importFrom ggseg.formats is_ggseg_atlas
 "_PACKAGE"

--- a/inst/templates/atlas-fallback/R/data.R
+++ b/inst/templates/atlas-fallback/R/data.R
@@ -11,7 +11,6 @@
 #' Example: Author A et al. (Year). Title. \doi{10.xxxx/xxxxx}
 #'
 #' @return A [ggseg.formats::ggseg_atlas] object.
-#' @import ggseg.formats
 #' @export
 #' @examples
 #' ATLASNAME()


### PR DESCRIPTION
## Summary

The bundled fallback atlas-package template (`inst/templates/atlas-fallback/`) used `@import ggseg.formats` in `R/data.R` and `R/PKGNAME-package.R`. goodpractice's `no_import_package_as_a_whole` check then fails in generated atlas packages; this surfaced in ggsegverse/ggsegNeuromorphometrics.

The generated atlas functions only need the ggseg.formats namespace loaded so the `ggseg_atlas` methods dispatch, and `@importFrom ggseg.formats is_ggseg_atlas` does that. This mirrors ggsegverse/ggseg-atlas-template#7, keeping the two template copies in sync.

Dev version 1.9.9.9019 with a NEWS entry.

## Test Plan

- [x] Full local suite passes
- [x] Same change applied in ggsegNeuromorphometrics: its tests pass, and code-quality (good-practice) went green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)