### PR TITLE
Render the atlas in the template README with plot()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg.extra
 Title: Create Brain Atlases for the 'ggsegverse' Plotting Ecosystem
-Version: 1.9.9.9019
+Version: 1.9.9.9020
 Authors@R: c(
     person(
         given = "Athanasia Mo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# ggseg.extra 1.9.9.9020
+
+- The bundled atlas-package template's README now renders the atlas with an
+  evaluated `plot()` chunk, which ggseg.formats provides, instead of an
+  unevaluated one that needed ggseg and theme tweaks. Mirrors
+  ggsegverse/ggseg-atlas-template's README.
+
 # ggseg.extra 1.9.9.9019
 
 - The bundled atlas-package template imports only `is_ggseg_atlas()` from

--- a/inst/templates/atlas-fallback/README.qmd
+++ b/inst/templates/atlas-fallback/README.qmd
@@ -65,16 +65,9 @@ pak::pak("ggsegverse/PKGNAME")
 
 ```{r}
 #| label: plot-2d
-#| eval: false
-library(ggseg)
 library(PKGNAME)
 
-plot(ATLASNAME()) +
-  theme(
-    legend.position = "bottom",
-    legend.text = element_text(size = 7)
-  ) +
-  guides(fill = guide_legend(ncol = 4))
+plot(ATLASNAME())
 ```
 
 ## Code of Conduct


### PR DESCRIPTION
## Summary

The bundled fallback atlas template (`inst/templates/atlas-fallback/README.qmd`) had an unevaluated usage chunk that attached ggseg and added legend `theme()`/`guides()` tweaks, so generated atlas packages showed no figure. `plot()` on a `ggseg_atlas` comes from ggseg.formats, which every atlas package imports, so the chunk is now evaluated and minimal (`library(PKGNAME)`; `plot(ATLASNAME())`). This matches how ggsegFreeSurfer renders its atlases and mirrors the same change in ggsegverse/ggseg-atlas-template.

Dev version 1.9.9.9020 with a NEWS entry.

## Test Plan

- [x] Full local suite passes
- [x] `plot()` on a `ggseg_atlas` renders to a graphics device without ggseg attached
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)