### PR TITLE
Reject cached intermediates written by a different pipeline version

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -110,7 +110,9 @@ Organise NEWS by user-facing and developer facing changes, and headings for mino
 
 - Pipeline intermediates are stamped with `cache_format_version()`
   (`R/cache_version.R`) in a `cache_manifest.rds` sidecar, and a cache
-  stamped with a different version is recomputed or rejected.
+  stamped with a different version is recomputed or rejected. That
+  function's documentation is the canonical list of what is and is not
+  stamped.
 - When a change makes existing intermediates **wrong** rather than merely
   old — a fix to surface projection, label classification, contour
   extraction or anything else whose cached output would otherwise be reused

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,3 +104,19 @@ only add information that is relevant for the R-package to NEWS.md.
 Any other changes related to workflows, pkgdown etc are not relevant to the R-package releases and thus dont shouldnt be listed in NEWS.
 
 Organise NEWS by user-facing and developer facing changes, and headings for minor vs breaking changes.
+
+
+### Cache format version
+
+- Pipeline intermediates are stamped with `cache_format_version()`
+  (`R/cache_version.R`) in a `cache_manifest.rds` sidecar, and a cache
+  stamped with a different version is recomputed or rejected.
+- When a change makes existing intermediates **wrong** rather than merely
+  old — a fix to surface projection, label classification, contour
+  extraction or anything else whose cached output would otherwise be reused
+  — bump `cache_format_version()` in the same PR. Nothing detects a
+  forgotten bump: the symptom is a maintainer rebuilding an atlas and
+  silently getting the old one.
+- Do not bump it for changes that leave existing intermediates valid.
+  Atlas rebuilds cost hours of FreeSurfer time, so an unnecessary bump
+  invalidates every atlas maintainer's cache for nothing.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg.extra
 Title: Create Brain Atlases for the 'ggsegverse' Plotting Ecosystem
-Version: 1.9.9.9023
+Version: 1.9.9.9024
 Authors@R: c(
     person(
         given = "Athanasia Mo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,13 +5,12 @@
   Rebuilding an atlas after a pipeline fix no longer silently reuses output
   the old pipeline made: a cache written by an older ggseg.extra is
   recomputed when its step is among the requested `steps`, and stops the
-  pipeline with the step to rerun when it is not. This covers the `.rds` step
-  caches of the cortical, subcortical, wholebrain, tract and cerebellar
-  pipelines and the contour `.rda` files. It does not cover the snapshot
-  images, processed images and masks, or the intermediate lookup table and
-  volume the wholebrain pipeline passes to the subcortical one: those are
-  still reused whenever the file exists, so a fix to snapshot rendering or
-  masking still needs its cache cleared by hand.
+  pipeline with the step to rerun when it is not. Stamped: the step caches,
+  the contour files, and the processed-image and mask directories. Still
+  reused whenever the file exists: the snapshot images, the subcortical mesh
+  directory, and the lookup table and volume the wholebrain pipeline passes
+  to the subcortical one, so a fix to any of those still needs its cache
+  cleared by hand.
 
 # ggseg.extra 1.9.9.9023
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,11 @@
   recomputed when its step is among the requested `steps`, and stops the
   pipeline with the step to rerun when it is not. This covers the `.rds` step
   caches of the cortical, subcortical, wholebrain, tract and cerebellar
-  pipelines as well as the contour `.rda` files.
+  pipelines and the contour `.rda` files. It does not cover the snapshot
+  images, processed images and masks, or the intermediate lookup table and
+  volume the wholebrain pipeline passes to the subcortical one: those are
+  still reused whenever the file exists, so a fix to snapshot rendering or
+  masking still needs its cache cleared by hand.
 
 # ggseg.extra 1.9.9.9023
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# ggseg.extra 1.9.9.9024
+
+- Cached pipeline intermediates now record the cache format version that
+  wrote them, in a `cache_manifest.rds` sidecar in the step directory.
+  Rebuilding an atlas after a pipeline fix no longer silently reuses output
+  the old pipeline made: a cache written by an older ggseg.extra is
+  recomputed when its step is among the requested `steps`, and stops the
+  pipeline with the step to rerun when it is not. This covers the `.rds` step
+  caches of the cortical, subcortical, wholebrain, tract and cerebellar
+  pipelines as well as the contour `.rda` files.
+
 # ggseg.extra 1.9.9.9023
 
 - Subcortical and tract atlases built with terra 1.9-46 came out upside down

--- a/R/atlas_cerebellar.R
+++ b/R/atlas_cerebellar.R
@@ -752,7 +752,7 @@ cerebellar_read_data <- function(config, dirs, read_fn) {
     }
     deep_data <- NULL
     if (file.exists(deep_file)) {
-      check_cache_current(deep_file, cerebellar_rerun_remedy)
+      check_cache_current(deep_file, step_rerun_remedy(1L))
       deep_data <- readRDS(deep_file)
     }
     return(list(
@@ -775,13 +775,10 @@ cerebellar_read_data <- function(config, dirs, read_fn) {
   components <- merge_deep_into_components(
     components,
     split$deep_data,
-    deep_file
+    dirs$base
   )
 
-  save_cache_rds(
-    components,
-    as.character(fs::path(dirs$base, "components.rds"))
-  )
+  save_cache_rds(dirs$base, components.rds = components)
   cli::cli_progress_done()
 
   list(components = components, deep_data = split$deep_data)
@@ -813,7 +810,7 @@ split_cerebellar_surface_deep <- function(atlas_data, config) {
 
 #' Merge deep-nuclei core/palette into surface components and cache them
 #' @noRd
-merge_deep_into_components <- function(components, deep_data, deep_file) {
+merge_deep_into_components <- function(components, deep_data, dir) {
   if (!is.null(deep_data) && nrow(deep_data) > 0) {
     deep_core <- dplyr::distinct(deep_data, hemi, region, label)
     components$core <- rbind(components$core, deep_core)
@@ -826,7 +823,7 @@ merge_deep_into_components <- function(components, deep_data, deep_file) {
       components$palette <- c(components$palette, deep_colours)
     }
 
-    save_cache_rds(deep_data, deep_file)
+    save_cache_rds(dir, deep_data.rds = deep_data)
   }
 
   components

--- a/R/atlas_cerebellar.R
+++ b/R/atlas_cerebellar.R
@@ -750,7 +750,11 @@ cerebellar_read_data <- function(config, dirs, read_fn) {
     if (config$verbose) {
       cli::cli_alert_success("Loaded cached atlas data")
     }
-    deep_data <- if (file.exists(deep_file)) readRDS(deep_file) else NULL
+    deep_data <- NULL
+    if (file.exists(deep_file)) {
+      check_cache_current(deep_file, cerebellar_rerun_remedy)
+      deep_data <- readRDS(deep_file)
+    }
     return(list(
       components = cached$data[["components.rds"]],
       deep_data = deep_data

--- a/R/atlas_cerebellar.R
+++ b/R/atlas_cerebellar.R
@@ -774,7 +774,10 @@ cerebellar_read_data <- function(config, dirs, read_fn) {
     deep_file
   )
 
-  saveRDS(components, as.character(fs::path(dirs$base, "components.rds")))
+  save_cache_rds(
+    components,
+    as.character(fs::path(dirs$base, "components.rds"))
+  )
   cli::cli_progress_done()
 
   list(components = components, deep_data = split$deep_data)
@@ -819,7 +822,7 @@ merge_deep_into_components <- function(components, deep_data, deep_file) {
       components$palette <- c(components$palette, deep_colours)
     }
 
-    saveRDS(deep_data, deep_file)
+    save_cache_rds(deep_data, deep_file)
   }
 
   components

--- a/R/atlas_cortical.R
+++ b/R/atlas_cortical.R
@@ -684,8 +684,11 @@ cortical_read_data <- function(
     data = ggseg_data_cortical(vertices = components$vertices_df)
   )
 
-  saveRDS(atlas_3d, as.character(fs::path(dirs$base, "atlas_3d.rds")))
-  saveRDS(components, as.character(fs::path(dirs$base, "components.rds")))
+  save_cache_rds(atlas_3d, as.character(fs::path(dirs$base, "atlas_3d.rds")))
+  save_cache_rds(
+    components,
+    as.character(fs::path(dirs$base, "components.rds"))
+  )
   cli::cli_progress_done()
 
   list(atlas_3d = atlas_3d, components = components)

--- a/R/atlas_cortical.R
+++ b/R/atlas_cortical.R
@@ -684,10 +684,10 @@ cortical_read_data <- function(
     data = ggseg_data_cortical(vertices = components$vertices_df)
   )
 
-  save_cache_rds(atlas_3d, as.character(fs::path(dirs$base, "atlas_3d.rds")))
   save_cache_rds(
-    components,
-    as.character(fs::path(dirs$base, "components.rds"))
+    dirs$base,
+    atlas_3d.rds = atlas_3d,
+    components.rds = components
   )
   cli::cli_progress_done()
 

--- a/R/atlas_geometry.R
+++ b/R/atlas_geometry.R
@@ -281,7 +281,9 @@ extract_contours <- function(
   contours <- combine_region_contours(contourobjs)
   contours$y_axis <- "up"
 
-  save(contours, file = as.character(fs::path(output_dir, "contours.rda")))
+  contour_file <- as.character(fs::path(output_dir, "contours.rda"))
+  save(contours, file = contour_file)
+  stamp_cache_files(contour_file)
 
   if (verbose) {
     cli::cli_progress_done()
@@ -315,6 +317,11 @@ read_mask_raster <- function(file) {
   terra::rast(values, extent = terra::ext(0, ncol(values), 0, nrow(values)))
 }
 
+
+contour_rerun_remedy <- paste(
+  "Rerun the contour extraction, smoothing and reduction steps;",
+  "cached snapshots and masks are reused."
+)
 
 #' Stop when cached contours predate the y-up coordinate convention
 #' @noRd
@@ -418,14 +425,18 @@ smooth_contours <- function(
   step = "",
   verbose = get_verbose() # nolint: object_usage_linter
 ) {
-  load_rda(as.character(fs::path(dir, "contours.rda")))
+  contour_file <- as.character(fs::path(dir, "contours.rda"))
+  load_rda(contour_file)
+  check_cache_current(contour_file, contour_rerun_remedy)
 
   contours <- filter_valid_geometries(contours)
   if (nrow(contours) == 0) {
     cli::cli_warn("No valid contours found after extraction")
   }
 
-  save(contours, file = as.character(fs::path(dir, "contours_smoothed.rda")))
+  smoothed_file <- as.character(fs::path(dir, "contours_smoothed.rda"))
+  save(contours, file = smoothed_file)
+  stamp_cache_files(smoothed_file)
   invisible(contours)
 }
 
@@ -444,13 +455,17 @@ reduce_vertex <- function(
   step = "",
   verbose = get_verbose() # nolint: object_usage_linter
 ) {
-  load_rda(as.character(fs::path(dir, "contours_smoothed.rda")))
+  smoothed_file <- as.character(fs::path(dir, "contours_smoothed.rda"))
+  load_rda(smoothed_file)
+  check_cache_current(smoothed_file, contour_rerun_remedy)
 
   contours <- filter_valid_geometries(contours)
   if (nrow(contours) == 0) {
     cli::cli_warn("No valid contours to simplify")
   }
-  save(contours, file = as.character(fs::path(dir, "contours_reduced.rda")))
+  reduced_file <- as.character(fs::path(dir, "contours_reduced.rda"))
+  save(contours, file = reduced_file)
+  stamp_cache_files(reduced_file)
   invisible(contours)
 }
 
@@ -783,6 +798,7 @@ arrange_contour_sf <- function(conts) {
 #' @importFrom sf st_combine st_coordinates st_geometry
 make_multipolygon <- function(contourfile) {
   load_rda(contourfile)
+  check_cache_current(contourfile, contour_rerun_remedy)
   check_contour_y_axis(contours, contourfile)
 
   contours <- contours |>

--- a/R/atlas_geometry.R
+++ b/R/atlas_geometry.R
@@ -265,7 +265,7 @@ extract_contours <- function(
     cli::cli_progress_step("{step} Extracting contours")
   }
 
-  regions <- list.files(input_dir, full.names = TRUE)
+  regions <- list.files(input_dir, full.names = TRUE, pattern = "\\.png$")
   region_names <- file_path_sans_ext(basename(regions))
 
   max_val <- probe_raster_max(regions)
@@ -281,9 +281,7 @@ extract_contours <- function(
   contours <- combine_region_contours(contourobjs)
   contours$y_axis <- "up"
 
-  contour_file <- as.character(fs::path(output_dir, "contours.rda"))
-  save(contours, file = contour_file)
-  stamp_cache_files(contour_file)
+  save_cache_rda(contours, output_dir, "contours.rda")
 
   if (verbose) {
     cli::cli_progress_done()
@@ -320,11 +318,8 @@ read_mask_raster <- function(file) {
 
 #' Stop when cached contours predate the y-up coordinate convention
 #'
-#' Redundant against real caches now that the manifest rejects any contour
-#' file another ggseg.extra wrote, and kept deliberately: it asserts the
-#' property the downstream code depends on rather than the provenance of the
-#' file carrying it, so it still catches contours assembled by hand or by a
-#' future path that writes them without the convention.
+#' Kept alongside the manifest check: this asserts the property the
+#' downstream code depends on, not the provenance of the file carrying it.
 #' @noRd
 check_contour_y_axis <- function(contours, contourfile) {
   if (identical(unique(contours$y_axis), "up")) {
@@ -426,18 +421,17 @@ smooth_contours <- function(
   step = "",
   verbose = get_verbose() # nolint: object_usage_linter
 ) {
-  contour_file <- as.character(fs::path(dir, "contours.rda"))
-  load_rda(contour_file)
-  check_cache_current(contour_file, contour_rerun_remedy)
+  load_cached_rda(
+    as.character(fs::path(dir, "contours.rda")),
+    contour_rerun_remedy
+  )
 
   contours <- filter_valid_geometries(contours)
   if (nrow(contours) == 0) {
     cli::cli_warn("No valid contours found after extraction")
   }
 
-  smoothed_file <- as.character(fs::path(dir, "contours_smoothed.rda"))
-  save(contours, file = smoothed_file)
-  stamp_cache_files(smoothed_file)
+  save_cache_rda(contours, dir, "contours_smoothed.rda")
   invisible(contours)
 }
 
@@ -456,17 +450,16 @@ reduce_vertex <- function(
   step = "",
   verbose = get_verbose() # nolint: object_usage_linter
 ) {
-  smoothed_file <- as.character(fs::path(dir, "contours_smoothed.rda"))
-  load_rda(smoothed_file)
-  check_cache_current(smoothed_file, contour_rerun_remedy)
+  load_cached_rda(
+    as.character(fs::path(dir, "contours_smoothed.rda")),
+    contour_rerun_remedy
+  )
 
   contours <- filter_valid_geometries(contours)
   if (nrow(contours) == 0) {
     cli::cli_warn("No valid contours to simplify")
   }
-  reduced_file <- as.character(fs::path(dir, "contours_reduced.rda"))
-  save(contours, file = reduced_file)
-  stamp_cache_files(reduced_file)
+  save_cache_rda(contours, dir, "contours_reduced.rda")
   invisible(contours)
 }
 
@@ -798,8 +791,7 @@ arrange_contour_sf <- function(conts) {
 #' @importFrom dplyr group_by summarise ungroup
 #' @importFrom sf st_combine st_coordinates st_geometry
 make_multipolygon <- function(contourfile) {
-  load_rda(contourfile)
-  check_cache_current(contourfile, contour_rerun_remedy)
+  load_cached_rda(contourfile, contour_rerun_remedy)
   check_contour_y_axis(contours, contourfile)
 
   contours <- contours |>

--- a/R/atlas_geometry.R
+++ b/R/atlas_geometry.R
@@ -318,12 +318,13 @@ read_mask_raster <- function(file) {
 }
 
 
-contour_rerun_remedy <- paste(
-  "Rerun the contour extraction, smoothing and reduction steps;",
-  "cached snapshots and masks are reused."
-)
-
 #' Stop when cached contours predate the y-up coordinate convention
+#'
+#' Redundant against real caches now that the manifest rejects any contour
+#' file another ggseg.extra wrote, and kept deliberately: it asserts the
+#' property the downstream code depends on rather than the provenance of the
+#' file carrying it, so it still catches contours assembled by hand or by a
+#' future path that writes them without the convention.
 #' @noRd
 check_contour_y_axis <- function(contours, contourfile) {
   if (identical(unique(contours$y_axis), "up")) {

--- a/R/atlas_subcortical.R
+++ b/R/atlas_subcortical.R
@@ -516,12 +516,9 @@ subcort_resolve_labels <- function(config, dirs) {
   }
 
   save_cache_rds(
-    colortable,
-    as.character(fs::path(dirs$base, "colortable.rds"))
-  )
-  save_cache_rds(
-    vol_labels,
-    as.character(fs::path(dirs$base, "vol_labels.rds"))
+    dirs$base,
+    colortable.rds = colortable,
+    vol_labels.rds = vol_labels
   )
   if (config$verbose) {
     cli::cli_progress_done()
@@ -594,10 +591,7 @@ subcort_resolve_meshes <- function(config, dirs, colortable) {
   if (config$verbose) {
     cli::cli_progress_done()
   }
-  save_cache_rds(
-    meshes_list,
-    as.character(fs::path(dirs$base, "meshes_list.rds"))
-  )
+  save_cache_rds(dirs$base, meshes_list.rds = meshes_list)
   meshes_list
 }
 
@@ -628,10 +622,7 @@ subcort_resolve_components <- function(config, dirs, colortable, meshes_list) {
   }
 
   components <- subcort_build_components(colortable, meshes_list)
-  save_cache_rds(
-    components,
-    as.character(fs::path(dirs$base, "components.rds"))
-  )
+  save_cache_rds(dirs$base, components.rds = components)
   if (config$verbose) {
     cli::cli_progress_done()
   }
@@ -678,10 +669,10 @@ subcort_resolve_snapshots <- function(config, dirs, colortable, slabs) {
     config$skip_existing
   )
 
-  save_cache_rds(result$slabs, as.character(fs::path(dirs$base, "slabs.rds")))
   save_cache_rds(
-    result$cortex_slices,
-    as.character(fs::path(dirs$base, "cortex_slices.rds"))
+    dirs$base,
+    slabs.rds = result$slabs,
+    cortex_slices.rds = result$cortex_slices
   )
   if (config$verbose) {
     cli::cli_progress_done()

--- a/R/atlas_subcortical.R
+++ b/R/atlas_subcortical.R
@@ -515,8 +515,14 @@ subcort_resolve_labels <- function(config, dirs) {
     cli::cli_alert_success("Found {nrow(colortable)} subcortical structures")
   }
 
-  saveRDS(colortable, as.character(fs::path(dirs$base, "colortable.rds")))
-  saveRDS(vol_labels, as.character(fs::path(dirs$base, "vol_labels.rds")))
+  save_cache_rds(
+    colortable,
+    as.character(fs::path(dirs$base, "colortable.rds"))
+  )
+  save_cache_rds(
+    vol_labels,
+    as.character(fs::path(dirs$base, "vol_labels.rds"))
+  )
   if (config$verbose) {
     cli::cli_progress_done()
   }
@@ -588,7 +594,10 @@ subcort_resolve_meshes <- function(config, dirs, colortable) {
   if (config$verbose) {
     cli::cli_progress_done()
   }
-  saveRDS(meshes_list, as.character(fs::path(dirs$base, "meshes_list.rds")))
+  save_cache_rds(
+    meshes_list,
+    as.character(fs::path(dirs$base, "meshes_list.rds"))
+  )
   meshes_list
 }
 
@@ -619,7 +628,10 @@ subcort_resolve_components <- function(config, dirs, colortable, meshes_list) {
   }
 
   components <- subcort_build_components(colortable, meshes_list)
-  saveRDS(components, as.character(fs::path(dirs$base, "components.rds")))
+  save_cache_rds(
+    components,
+    as.character(fs::path(dirs$base, "components.rds"))
+  )
   if (config$verbose) {
     cli::cli_progress_done()
   }
@@ -666,8 +678,8 @@ subcort_resolve_snapshots <- function(config, dirs, colortable, slabs) {
     config$skip_existing
   )
 
-  saveRDS(result$slabs, as.character(fs::path(dirs$base, "slabs.rds")))
-  saveRDS(
+  save_cache_rds(result$slabs, as.character(fs::path(dirs$base, "slabs.rds")))
+  save_cache_rds(
     result$cortex_slices,
     as.character(fs::path(dirs$base, "cortex_slices.rds"))
   )

--- a/R/atlas_tracts.R
+++ b/R/atlas_tracts.R
@@ -385,10 +385,7 @@ tract_resolve_step1 <- function(
 
   step1_data <- tract_step1_data(config, prepared, built)
 
-  save_cache_rds(
-    step1_data,
-    as.character(fs::path(dirs$base, "step1_data.rds"))
-  )
+  save_cache_rds(dirs$base, step1_data.rds = step1_data)
   step1_data
 }
 
@@ -524,8 +521,11 @@ tract_run_snapshots <- function(config, dirs, step1, input_aseg, slabs, files) {
     step1$center_offset
   )
 
-  save_cache_rds(result$slabs, files[1])
-  save_cache_rds(result$cortex_slices, files[2])
+  save_cache_rds(
+    dirs$base,
+    slabs.rds = result$slabs,
+    cortex_slices.rds = result$cortex_slices
+  )
   if (config$verbose) {
     cli::cli_progress_done()
   }

--- a/R/atlas_tracts.R
+++ b/R/atlas_tracts.R
@@ -385,7 +385,10 @@ tract_resolve_step1 <- function(
 
   step1_data <- tract_step1_data(config, prepared, built)
 
-  saveRDS(step1_data, as.character(fs::path(dirs$base, "step1_data.rds")))
+  save_cache_rds(
+    step1_data,
+    as.character(fs::path(dirs$base, "step1_data.rds"))
+  )
   step1_data
 }
 
@@ -521,8 +524,8 @@ tract_run_snapshots <- function(config, dirs, step1, input_aseg, slabs, files) {
     step1$center_offset
   )
 
-  saveRDS(result$slabs, files[1])
-  saveRDS(result$cortex_slices, files[2])
+  save_cache_rds(result$slabs, files[1])
+  save_cache_rds(result$cortex_slices, files[2])
   if (config$verbose) {
     cli::cli_progress_done()
   }

--- a/R/atlas_wholebrain.R
+++ b/R/atlas_wholebrain.R
@@ -710,12 +710,9 @@ wholebrain_compute_projection <- function(config, dirs) {
   )
 
   save_cache_rds(
-    atlas_data,
-    as.character(fs::path(dirs$base, "atlas_data.rds"))
-  )
-  save_cache_rds(
-    colortable,
-    as.character(fs::path(dirs$base, "colortable.rds"))
+    dirs$base,
+    atlas_data.rds = atlas_data,
+    colortable.rds = colortable
   )
   if (config$verbose) {
     cli::cli_progress_done()
@@ -1023,7 +1020,7 @@ wholebrain_resolve_split <- function(
     verbose = config$verbose
   )
 
-  save_cache_rds(split, as.character(fs::path(dirs$base, "label_split.rds")))
+  save_cache_rds(dirs$base, label_split.rds = split)
   if (config$verbose) {
     cli::cli_progress_done()
   }

--- a/R/atlas_wholebrain.R
+++ b/R/atlas_wholebrain.R
@@ -709,8 +709,14 @@ wholebrain_compute_projection <- function(config, dirs) {
     verbose = config$verbose
   )
 
-  saveRDS(atlas_data, as.character(fs::path(dirs$base, "atlas_data.rds")))
-  saveRDS(colortable, as.character(fs::path(dirs$base, "colortable.rds")))
+  save_cache_rds(
+    atlas_data,
+    as.character(fs::path(dirs$base, "atlas_data.rds"))
+  )
+  save_cache_rds(
+    colortable,
+    as.character(fs::path(dirs$base, "colortable.rds"))
+  )
   if (config$verbose) {
     cli::cli_progress_done()
   }
@@ -1017,7 +1023,7 @@ wholebrain_resolve_split <- function(
     verbose = config$verbose
   )
 
-  saveRDS(split, as.character(fs::path(dirs$base, "label_split.rds")))
+  save_cache_rds(split, as.character(fs::path(dirs$base, "label_split.rds")))
   if (config$verbose) {
     cli::cli_progress_done()
   }

--- a/R/cache_version.R
+++ b/R/cache_version.R
@@ -2,9 +2,18 @@
 
 #' Format version of cached pipeline intermediates
 #'
-#' Bump this whenever a pipeline change makes previously cached intermediates
-#' wrong rather than merely old, so a rebuilt atlas cannot silently reuse
-#' output from the pipeline the change fixed.
+#' Bump this by hand whenever a pipeline change makes previously cached
+#' intermediates wrong rather than merely old, so a rebuilt atlas cannot
+#' silently reuse output from the pipeline the change fixed.
+#'
+#' What this covers: the serialized step caches written by
+#' `save_cache_rds()` and the contour `.rda` files. What it does not cover:
+#' the snapshot PNGs, processed images and masks, and the intermediate LUT
+#' and volume the wholebrain pipeline hands to the subcortical one. Those are
+#' still reused on file existence alone, so a fix to snapshot rendering or
+#' masking still needs its cache purged by hand. The image directories are
+#' scanned with `list.files()`, which would read a manifest sidecar as a
+#' region or image.
 #'
 #' @return Integer format version.
 #' @noRd
@@ -14,27 +23,69 @@ cache_format_version <- function() {
 
 cache_manifest_name <- "cache_manifest.rds"
 
+contour_rerun_remedy <- paste(
+  "Rerun the contour extraction, smoothing and reduction steps;",
+  "cached snapshots and masks are reused."
+)
+
+cerebellar_rerun_remedy <-
+  "Include step 1 in the steps argument to reread the parcellation."
+
 #' @noRd
 cache_manifest_file <- function(dir) {
   as.character(fs::path(dir, cache_manifest_name))
 }
 
+#' @noRd
+empty_cache_manifest <- function() {
+  data.frame(
+    file = character(),
+    version = integer(),
+    mtime = numeric(),
+    stringsAsFactors = FALSE
+  )
+}
+
 #' Read the cache manifest of a step directory
 #'
+#' A manifest that is missing, unreadable or malformed reads as empty, which
+#' marks every file in the directory stale. That is the safe direction: the
+#' pipeline reruns work rather than trusting output it cannot vouch for.
+#'
 #' @param dir Directory holding cached intermediates.
-#' @return Named integer vector mapping file name to format version. Empty
-#'   when the directory has no readable manifest.
+#' @return Data frame with `file`, `version` and `mtime` columns.
 #' @noRd
 read_cache_manifest <- function(dir) {
   manifest_file <- cache_manifest_file(dir)
   if (!file.exists(manifest_file)) {
-    return(integer())
+    return(empty_cache_manifest())
   }
   manifest <- tryCatch(readRDS(manifest_file), error = function(e) NULL)
-  if (!is.integer(manifest) || is.null(names(manifest))) {
-    return(integer())
+  if (
+    !is.data.frame(manifest) ||
+      !all(c("file", "version", "mtime") %in% names(manifest))
+  ) {
+    return(empty_cache_manifest())
   }
   manifest
+}
+
+#' Write a cache manifest without leaving a truncated file behind
+#'
+#' These builds run for hours and are routinely interrupted. Truncating the
+#' manifest in place means a Ctrl-C mid-write loses every stamp in the
+#' directory and turns the next partial rerun into an abort, so the new
+#' manifest is staged beside it and renamed into place instead.
+#' @noRd
+write_cache_manifest <- function(dir, manifest) {
+  manifest_file <- cache_manifest_file(dir)
+  staged <- tempfile(pattern = "cache_manifest", tmpdir = dir, fileext = ".rds")
+  saveRDS(manifest, staged)
+  if (!file.rename(staged, manifest_file)) {
+    unlink(staged)
+    cli::cli_warn("Could not update the cache manifest in {.path {dir}}")
+  }
+  invisible(manifest_file)
 }
 
 #' Record the current format version for freshly written cache files
@@ -42,6 +93,8 @@ read_cache_manifest <- function(dir) {
 #' The stamp lives in a sidecar manifest rather than on the objects
 #' themselves: attributes do not survive the dplyr verbs the pipelines apply
 #' to loaded data, and the same manifest covers `.rds` and `.rda` caches.
+#' Each entry records the file's modification time as well as the format
+#' version, so a stamped name cannot vouch for content written after it.
 #'
 #' @param files Character vector of cache file paths just written.
 #' @return The files, invisibly.
@@ -49,9 +102,19 @@ read_cache_manifest <- function(dir) {
 stamp_cache_files <- function(files) {
   dirs <- dirname(files)
   for (dir in unique(dirs)) {
+    stamped <- files[dirs == dir]
     manifest <- read_cache_manifest(dir)
-    manifest[basename(files[dirs == dir])] <- cache_format_version()
-    saveRDS(manifest, cache_manifest_file(dir))
+    manifest <- manifest[!manifest$file %in% basename(stamped), , drop = FALSE]
+    manifest <- rbind(
+      manifest,
+      data.frame(
+        file = basename(stamped),
+        version = cache_format_version(),
+        mtime = as.numeric(file.mtime(stamped)),
+        stringsAsFactors = FALSE
+      )
+    )
+    write_cache_manifest(dir, manifest)
   }
   invisible(files)
 }
@@ -64,26 +127,67 @@ save_cache_rds <- function(object, file) {
   invisible(file)
 }
 
+#' Format version a cache file was stamped with
+#'
+#' @return The recorded version, or `NA_integer_` when the file has no entry
+#'   or has changed since it was stamped.
 #' @noRd
-cache_file_version <- function(file) {
-  version <- read_cache_manifest(dirname(file))[basename(file)]
-  if (is.na(version)) NA_integer_ else unname(version)
+cache_file_version <- function(file, manifest = NULL) {
+  if (is.null(manifest)) {
+    manifest <- read_cache_manifest(dirname(file))
+  }
+  entry <- manifest[manifest$file == basename(file), , drop = FALSE]
+  if (nrow(entry) != 1L) {
+    return(NA_integer_)
+  }
+  if (!identical(entry$mtime, as.numeric(file.mtime(file)))) {
+    return(NA_integer_)
+  }
+  as.integer(entry$version)
 }
 
 #' Cache files not written by the current cache format version
 #'
 #' @param files Character vector of cache file paths.
-#' @return The subset of `files` that are missing a stamp or carry an older
-#'   or newer one.
+#' @return The subset of `files` missing a stamp, carrying a different
+#'   format version, or changed since they were stamped.
 #' @noRd
 stale_cache_files <- function(files) {
-  is_stale <- vapply(
-    files,
-    function(file) !identical(cache_file_version(file), cache_format_version()),
-    logical(1),
-    USE.NAMES = FALSE
-  )
+  dirs <- dirname(files)
+  is_stale <- logical(length(files))
+  for (dir in unique(dirs)) {
+    in_dir <- dirs == dir
+    manifest <- read_cache_manifest(dir)
+    is_stale[in_dir] <- vapply(
+      files[in_dir],
+      function(file) {
+        !identical(cache_file_version(file, manifest), cache_format_version())
+      },
+      logical(1),
+      USE.NAMES = FALSE
+    )
+  }
   files[is_stale]
+}
+
+#' Name the ggseg.extra that wrote a set of stale caches
+#'
+#' Stamps from a newer ggseg.extra are rejected just as older ones are, so
+#' the message says which it was rather than assuming a downgrade is an
+#' upgrade.
+#' @noRd
+stale_cache_origin <- function(files) {
+  versions <- vapply(files, cache_file_version, integer(1), USE.NAMES = FALSE)
+  known <- versions[!is.na(versions)]
+  if (
+    length(known) == length(versions) && all(known > cache_format_version())
+  ) {
+    return("a newer ggseg.extra")
+  }
+  if (all(is.na(versions)) || all(known < cache_format_version())) {
+    return("an older ggseg.extra")
+  }
+  "a different version of ggseg.extra"
 }
 
 #' Stop when cached files were written by another ggseg.extra
@@ -97,19 +201,21 @@ check_cache_current <- function(files, remedy) {
   if (length(stale) == 0L) {
     return(invisible(files))
   }
+  origin <- stale_cache_origin(stale) # nolint: object_usage_linter.
   cli::cli_abort(c(
-    "Cached {.path {stale}} {?was/were} written by an older ggseg.extra.",
+    "Cached {.path {stale}} {?was/were} written by {origin}.",
     "i" = "{cli::qty(length(stale))}Reusing {?it/them} would rebuild the
-      atlas the old pipeline made.",
+      atlas that pipeline made.",
     "i" = remedy
   ))
 }
 
 #' @noRd
 abort_stale_step_cache <- function(files, step_num, step_name) {
+  origin <- stale_cache_origin(files) # nolint: object_usage_linter.
   # fmt: skip
   cli::cli_abort(c(
-    "{step_name} has cached output from an older ggseg.extra.",
+    "{step_name} has cached output from {origin}.",
     "i" = "Stale: {.path {files}}",
     "i" = "{cli::qty(length(files))}Include step {step_num} in the steps
       argument to rebuild {?it/them}; steps whose cache is current are

--- a/R/cache_version.R
+++ b/R/cache_version.R
@@ -6,14 +6,13 @@
 #' intermediates wrong rather than merely old, so a rebuilt atlas cannot
 #' silently reuse output from the pipeline the change fixed.
 #'
-#' What this covers: the serialized step caches written by
-#' `save_cache_rds()` and the contour `.rda` files. What it does not cover:
-#' the snapshot PNGs, processed images and masks, and the intermediate LUT
-#' and volume the wholebrain pipeline hands to the subcortical one. Those are
-#' still reused on file existence alone, so a fix to snapshot rendering or
-#' masking still needs its cache purged by hand. The image directories are
-#' scanned with `list.files()`, which would read a manifest sidecar as a
-#' region or image.
+#' Stamped, and so checked before reuse: the `.rds` step caches, the contour
+#' `.rda` files, and the processed-image and mask directories. Not stamped,
+#' and so still reused whenever the file exists: the snapshot PNGs, the
+#' subcortical mesh directory (`dirs$meshes`), and the lookup table and
+#' volume the wholebrain pipeline hands to the subcortical one. This is the
+#' canonical list; `NEWS.md` and `.github/copilot-instructions.md` point
+#' here rather than restating it.
 #'
 #' @return Integer format version.
 #' @noRd
@@ -23,49 +22,45 @@ cache_format_version <- function() {
 
 cache_manifest_name <- "cache_manifest.rds"
 
+cache_dir_entry <- "."
+
 contour_rerun_remedy <- paste(
   "Rerun the contour extraction, smoothing and reduction steps;",
   "cached snapshots and masks are reused."
 )
 
-cerebellar_rerun_remedy <-
-  "Include step 1 in the steps argument to reread the parcellation."
+image_rerun_remedy <- paste(
+  "Rerun the image-processing step to rebuild the masks;",
+  "the snapshots they are made from are reused."
+)
+
+#' @noRd
+step_rerun_remedy <- function(step_num) {
+  cli::format_inline(
+    "Include step {step_num} in the steps argument to rebuild it; ",
+    "steps whose cache is current are still reused."
+  )
+}
 
 #' @noRd
 cache_manifest_file <- function(dir) {
   as.character(fs::path(dir, cache_manifest_name))
 }
 
-#' @noRd
-empty_cache_manifest <- function() {
-  data.frame(
-    file = character(),
-    version = integer(),
-    mtime = numeric(),
-    stringsAsFactors = FALSE
-  )
-}
-
-#' Read the cache manifest of a step directory
+#' Read a directory's manifest of cache name to format version
 #'
-#' A manifest that is missing, unreadable or malformed reads as empty, which
-#' marks every file in the directory stale. That is the safe direction: the
-#' pipeline reruns work rather than trusting output it cannot vouch for.
-#'
-#' @param dir Directory holding cached intermediates.
-#' @return Data frame with `file`, `version` and `mtime` columns.
+#' A missing, unreadable or malformed manifest reads as empty, which marks
+#' that directory's caches stale: the pipeline redoes the work rather than
+#' trusting output it cannot vouch for.
 #' @noRd
 read_cache_manifest <- function(dir) {
   manifest_file <- cache_manifest_file(dir)
   if (!file.exists(manifest_file)) {
-    return(empty_cache_manifest())
+    return(integer())
   }
   manifest <- tryCatch(readRDS(manifest_file), error = function(e) NULL)
-  if (
-    !is.data.frame(manifest) ||
-      !all(c("file", "version", "mtime") %in% names(manifest))
-  ) {
-    return(empty_cache_manifest())
+  if (!is.integer(manifest) || is.null(names(manifest))) {
+    return(integer())
   }
   manifest
 }
@@ -93,132 +88,138 @@ write_cache_manifest <- function(dir, manifest) {
 #' The stamp lives in a sidecar manifest rather than on the objects
 #' themselves: attributes do not survive the dplyr verbs the pipelines apply
 #' to loaded data, and the same manifest covers `.rds` and `.rda` caches.
-#' Each entry records the file's modification time as well as the format
-#' version, so a stamped name cannot vouch for content written after it.
 #'
-#' @param files Character vector of cache file paths just written.
-#' @return The files, invisibly.
+#' Call this from the main thread only. It is a read-modify-write on state
+#' shared by every cache in the directory, and the atomic rename protects
+#' against a torn manifest, not against two workers each dropping the
+#' other's rows.
 #' @noRd
 stamp_cache_files <- function(files) {
   dirs <- dirname(files)
   for (dir in unique(dirs)) {
-    stamped <- files[dirs == dir]
     manifest <- read_cache_manifest(dir)
-    manifest <- manifest[!manifest$file %in% basename(stamped), , drop = FALSE]
-    manifest <- rbind(
-      manifest,
-      data.frame(
-        file = basename(stamped),
-        version = cache_format_version(),
-        mtime = as.numeric(file.mtime(stamped)),
-        stringsAsFactors = FALSE
-      )
-    )
+    manifest[basename(files[dirs == dir])] <- cache_format_version()
     write_cache_manifest(dir, manifest)
   }
   invisible(files)
 }
 
-#' Save a pipeline intermediate and stamp its format version
+#' Stamp a directory whose contents are produced and reused as one unit
 #' @noRd
-save_cache_rds <- function(object, file) {
-  saveRDS(object, file)
+stamp_cache_dir <- function(dir) {
+  manifest <- read_cache_manifest(dir)
+  manifest[cache_dir_entry] <- cache_format_version()
+  write_cache_manifest(dir, manifest)
+  invisible(dir)
+}
+
+#' Save pipeline intermediates into a step directory and stamp them
+#'
+#' @param dir Step directory to write into.
+#' @param ... Objects to save, each named by the file to write it to. Pass
+#'   every file a step writes in one call, so the manifest is written once.
+#' @return The files written, invisibly.
+#' @noRd
+save_cache_rds <- function(dir, ...) {
+  objects <- list(...)
+  files <- as.character(fs::path(dir, names(objects)))
+  for (i in seq_along(objects)) {
+    saveRDS(objects[[i]], files[[i]])
+  }
+  stamp_cache_files(files)
+  invisible(files)
+}
+
+#' Save contours as an `.rda` cache and stamp them
+#'
+#' The object is stored under the name `contours`, which is what
+#' `load_cached_rda()` and the pipeline's loaders expect to find.
+#' @noRd
+save_cache_rda <- function(contours, dir, name) {
+  file <- as.character(fs::path(dir, name))
+  save(contours, file = file)
   stamp_cache_files(file)
   invisible(file)
 }
 
-#' Format version a cache file was stamped with
-#'
-#' @return The recorded version, or `NA_integer_` when the file has no entry
-#'   or has changed since it was stamped.
+#' Load an `.rda` cache, rejecting a stale one before deserializing it
+#' @noRd
+load_cached_rda <- function(file, remedy, envir = parent.frame()) {
+  if (file.exists(file)) {
+    check_cache_current(file, remedy)
+  }
+  load_rda(file, envir = envir)
+}
+
 #' @noRd
 cache_file_version <- function(file, manifest = NULL) {
   if (is.null(manifest)) {
     manifest <- read_cache_manifest(dirname(file))
   }
-  entry <- manifest[manifest$file == basename(file), , drop = FALSE]
-  if (nrow(entry) != 1L) {
-    return(NA_integer_)
-  }
-  if (!identical(entry$mtime, as.numeric(file.mtime(file)))) {
-    return(NA_integer_)
-  }
-  as.integer(entry$version)
+  version <- manifest[basename(file)]
+  if (is.na(version)) NA_integer_ else unname(version)
 }
 
-#' Cache files not written by the current cache format version
-#'
-#' @param files Character vector of cache file paths.
-#' @return The subset of `files` missing a stamp, carrying a different
-#'   format version, or changed since they were stamped.
+#' Format version each file was stamped with, reading each manifest once
 #' @noRd
-stale_cache_files <- function(files) {
+cache_file_versions <- function(files) {
   dirs <- dirname(files)
-  is_stale <- logical(length(files))
+  versions <- rep(NA_integer_, length(files))
   for (dir in unique(dirs)) {
     in_dir <- dirs == dir
     manifest <- read_cache_manifest(dir)
-    is_stale[in_dir] <- vapply(
+    versions[in_dir] <- vapply(
       files[in_dir],
-      function(file) {
-        !identical(cache_file_version(file, manifest), cache_format_version())
-      },
-      logical(1),
+      cache_file_version,
+      integer(1),
+      manifest = manifest,
       USE.NAMES = FALSE
     )
   }
-  files[is_stale]
+  versions
 }
 
-#' Name the ggseg.extra that wrote a set of stale caches
-#'
-#' Stamps from a newer ggseg.extra are rejected just as older ones are, so
-#' the message says which it was rather than assuming a downgrade is an
-#' upgrade.
 #' @noRd
-stale_cache_origin <- function(files) {
-  versions <- vapply(files, cache_file_version, integer(1), USE.NAMES = FALSE)
-  known <- versions[!is.na(versions)]
-  if (
-    length(known) == length(versions) && all(known > cache_format_version())
-  ) {
-    return("a newer ggseg.extra")
-  }
-  if (all(is.na(versions)) || all(known < cache_format_version())) {
-    return("an older ggseg.extra")
-  }
-  "a different version of ggseg.extra"
+is_stale_version <- function(versions) {
+  is.na(versions) | versions != cache_format_version()
 }
 
-#' Stop when cached files were written by another ggseg.extra
+#' @noRd
+stale_cache_files <- function(files) {
+  files[is_stale_version(cache_file_versions(files))]
+}
+
+#' Stop when caches were written by a different cache format version
 #'
 #' @param files Cache files about to be reused.
-#' @param remedy Instruction telling the user which step to rerun.
+#' @param remedy Instruction telling the user how to rebuild them.
 #' @return The files, invisibly, when all are current.
 #' @noRd
 check_cache_current <- function(files, remedy) {
-  stale <- stale_cache_files(files)
-  if (length(stale) == 0L) {
+  versions <- cache_file_versions(files)
+  stale <- is_stale_version(versions)
+  if (!any(stale)) {
     return(invisible(files))
   }
-  origin <- stale_cache_origin(stale) # nolint: object_usage_linter.
-  cli::cli_abort(c(
-    "Cached {.path {stale}} {?was/were} written by {origin}.",
-    "i" = "{cli::qty(length(stale))}Reusing {?it/them} would rebuild the
-      atlas that pipeline made.",
-    "i" = remedy
-  ))
+  abort_stale_cache(files[stale], versions[stale], remedy)
 }
 
 #' @noRd
-abort_stale_step_cache <- function(files, step_num, step_name) {
-  origin <- stale_cache_origin(files) # nolint: object_usage_linter.
-  # fmt: skip
+check_cache_dir <- function(dir, remedy) {
+  version <- cache_file_version(as.character(fs::path(dir, cache_dir_entry)))
+  if (!is_stale_version(version)) {
+    return(invisible(dir))
+  }
+  abort_stale_cache(dir, version, remedy)
+}
+
+#' @noRd
+abort_stale_cache <- function(paths, versions, remedy) {
+  # nolint next: object_usage_linter.
+  found <- unique(ifelse(is.na(versions), "none", as.character(versions)))
   cli::cli_abort(c(
-    "{step_name} has cached output from {origin}.",
-    "i" = "Stale: {.path {files}}",
-    "i" = "{cli::qty(length(files))}Include step {step_num} in the steps
-      argument to rebuild {?it/them}; steps whose cache is current are
-      still reused."
+    "Cached {.path {paths}} {?was/were} written by cache format {found}.",
+    "i" = "This ggseg.extra writes cache format {cache_format_version()}.",
+    "i" = remedy
   ))
 }

--- a/R/cache_version.R
+++ b/R/cache_version.R
@@ -1,0 +1,118 @@
+# Cache format versioning ----
+
+#' Format version of cached pipeline intermediates
+#'
+#' Bump this whenever a pipeline change makes previously cached intermediates
+#' wrong rather than merely old, so a rebuilt atlas cannot silently reuse
+#' output from the pipeline the change fixed.
+#'
+#' @return Integer format version.
+#' @noRd
+cache_format_version <- function() {
+  1L
+}
+
+cache_manifest_name <- "cache_manifest.rds"
+
+#' @noRd
+cache_manifest_file <- function(dir) {
+  as.character(fs::path(dir, cache_manifest_name))
+}
+
+#' Read the cache manifest of a step directory
+#'
+#' @param dir Directory holding cached intermediates.
+#' @return Named integer vector mapping file name to format version. Empty
+#'   when the directory has no readable manifest.
+#' @noRd
+read_cache_manifest <- function(dir) {
+  manifest_file <- cache_manifest_file(dir)
+  if (!file.exists(manifest_file)) {
+    return(integer())
+  }
+  manifest <- tryCatch(readRDS(manifest_file), error = function(e) NULL)
+  if (!is.integer(manifest) || is.null(names(manifest))) {
+    return(integer())
+  }
+  manifest
+}
+
+#' Record the current format version for freshly written cache files
+#'
+#' The stamp lives in a sidecar manifest rather than on the objects
+#' themselves: attributes do not survive the dplyr verbs the pipelines apply
+#' to loaded data, and the same manifest covers `.rds` and `.rda` caches.
+#'
+#' @param files Character vector of cache file paths just written.
+#' @return The files, invisibly.
+#' @noRd
+stamp_cache_files <- function(files) {
+  dirs <- dirname(files)
+  for (dir in unique(dirs)) {
+    manifest <- read_cache_manifest(dir)
+    manifest[basename(files[dirs == dir])] <- cache_format_version()
+    saveRDS(manifest, cache_manifest_file(dir))
+  }
+  invisible(files)
+}
+
+#' Save a pipeline intermediate and stamp its format version
+#' @noRd
+save_cache_rds <- function(object, file) {
+  saveRDS(object, file)
+  stamp_cache_files(file)
+  invisible(file)
+}
+
+#' @noRd
+cache_file_version <- function(file) {
+  version <- read_cache_manifest(dirname(file))[basename(file)]
+  if (is.na(version)) NA_integer_ else unname(version)
+}
+
+#' Cache files not written by the current cache format version
+#'
+#' @param files Character vector of cache file paths.
+#' @return The subset of `files` that are missing a stamp or carry an older
+#'   or newer one.
+#' @noRd
+stale_cache_files <- function(files) {
+  is_stale <- vapply(
+    files,
+    function(file) !identical(cache_file_version(file), cache_format_version()),
+    logical(1),
+    USE.NAMES = FALSE
+  )
+  files[is_stale]
+}
+
+#' Stop when cached files were written by another ggseg.extra
+#'
+#' @param files Cache files about to be reused.
+#' @param remedy Instruction telling the user which step to rerun.
+#' @return The files, invisibly, when all are current.
+#' @noRd
+check_cache_current <- function(files, remedy) {
+  stale <- stale_cache_files(files)
+  if (length(stale) == 0L) {
+    return(invisible(files))
+  }
+  cli::cli_abort(c(
+    "Cached {.path {stale}} {?was/were} written by an older ggseg.extra.",
+    "i" = "{cli::qty(length(stale))}Reusing {?it/them} would rebuild the
+      atlas the old pipeline made.",
+    "i" = remedy
+  ))
+}
+
+#' @noRd
+abort_stale_step_cache <- function(files, step_num, step_name) {
+  # fmt: skip
+  cli::cli_abort(c(
+    "{step_name} has cached output from an older ggseg.extra.",
+    "i" = "Stale: {.path {files}}",
+    "i" = "{cli::qty(length(files))}Include step {step_num} in the steps
+      argument to rebuild {?it/them}; steps whose cache is current are
+      still reused."
+  ))
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -268,17 +268,18 @@ load_or_run_step <- function(
   files_exist <- all(file.exists(files))
   step_requested <- step_num %in% steps
 
-  if (files_exist && (skip_existing || !step_requested)) {
-    stale <- stale_cache_files(files)
-    if (length(stale) > 0L) {
-      if (!step_requested) {
-        abort_stale_step_cache(stale, step_num, step_name)
-      }
-      cli::cli_alert_info(
-        "{step_name}: cached output predates this ggseg.extra; recomputing."
-      )
-      return(list(run = TRUE, data = NULL))
-    }
+  reuses_cache <- files_exist && (skip_existing || !step_requested)
+  stale <- if (reuses_cache) stale_cache_files(files) else character()
+
+  if (length(stale) > 0L && !step_requested) {
+    check_cache_current(stale, step_rerun_remedy(step_num))
+  }
+
+  if (length(stale) > 0L) {
+    cli::cli_alert_info(
+      "{step_name}: cached output predates this ggseg.extra; recomputing."
+    )
+    return(list(run = TRUE, data = NULL))
   }
 
   if (files_exist && skip_existing) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -243,6 +243,8 @@ log_elapsed <- function(start_time) {
 #' Load or run a pipeline step
 #'
 #' Handles the logic for loading cached data or running a step:
+#' - If the cached files were written by an older ggseg.extra, recompute when
+#'   the step was requested and abort with the step to rerun when it was not
 #' - If skip_existing and files exist, load and return data
 #' - If step is in steps list, return NULL to signal step should run
 #' - If step not in steps and files don't exist, throw error
@@ -265,6 +267,19 @@ load_or_run_step <- function(
 ) {
   files_exist <- all(file.exists(files))
   step_requested <- step_num %in% steps
+
+  if (files_exist && (skip_existing || !step_requested)) {
+    stale <- stale_cache_files(files)
+    if (length(stale) > 0L) {
+      if (!step_requested) {
+        abort_stale_step_cache(stale, step_num, step_name)
+      }
+      cli::cli_alert_info(
+        "{step_name}: cached output predates this ggseg.extra; recomputing."
+      )
+      return(list(run = TRUE, data = NULL))
+    }
+  }
 
   if (files_exist && skip_existing) {
     data <- lapply(files, readRDS)

--- a/R/utils.R
+++ b/R/utils.R
@@ -269,23 +269,16 @@ load_or_run_step <- function(
   step_requested <- step_num %in% steps
 
   reuses_cache <- files_exist && (skip_existing || !step_requested)
-  stale <- if (reuses_cache) stale_cache_files(files) else character()
 
-  if (length(stale) > 0L && !step_requested) {
-    check_cache_current(stale, step_rerun_remedy(step_num))
-  }
+  recompute <- reuses_cache &&
+    recomputes_stale_cache(files, step_num, step_name, step_requested)
 
-  if (length(stale) > 0L) {
-    cli::cli_alert_info(
-      "{step_name}: cached output predates this ggseg.extra; recomputing."
-    )
+  if (recompute) {
     return(list(run = TRUE, data = NULL))
   }
 
   if (files_exist && skip_existing) {
-    data <- lapply(files, readRDS)
-    names(data) <- basename(files)
-    return(list(run = FALSE, data = data))
+    return(list(run = FALSE, data = read_step_cache(files)))
   }
 
   if (step_requested) {
@@ -293,20 +286,54 @@ load_or_run_step <- function(
   }
 
   if (!files_exist) {
-    missing <- files[!file.exists(files)] # nolint: object_usage_linter
-    # nolint start
-    cli::cli_abort(c(
-      "{step_name} was not run but required files are missing",
-      "i" = "Missing: {.path {missing}}",
-      "i" = "Include step {step_num} in the steps argument to
-      generate these files"
-    ))
-    # nolint end
+    abort_missing_step_files(files, step_num, step_name)
   }
 
+  list(run = FALSE, data = read_step_cache(files))
+}
+
+
+#' Whether a step's cache must be recomputed rather than reused
+#'
+#' Aborts instead when the step was not requested: the alternatives are
+#' reusing output this ggseg.extra cannot vouch for, or silently running
+#' work the caller excluded.
+#' @noRd
+recomputes_stale_cache <- function(files, step_num, step_name, step_requested) {
+  stale <- stale_cache_files(files)
+  if (length(stale) == 0L) {
+    return(FALSE)
+  }
+  if (!step_requested) {
+    check_cache_current(stale, step_rerun_remedy(step_num))
+  }
+  cli::cli_alert_info(
+    "{step_name}: cached output predates this ggseg.extra; recomputing."
+  )
+  TRUE
+}
+
+
+#' Read a step's cached files, named by the file they came from
+#' @noRd
+read_step_cache <- function(files) {
   data <- lapply(files, readRDS)
   names(data) <- basename(files)
-  list(run = FALSE, data = data)
+  data
+}
+
+
+#' @noRd
+abort_missing_step_files <- function(files, step_num, step_name) {
+  missing <- files[!file.exists(files)] # nolint: object_usage_linter
+  # nolint start
+  cli::cli_abort(c(
+    "{step_name} was not run but required files are missing",
+    "i" = "Missing: {.path {missing}}",
+    "i" = "Include step {step_num} in the steps argument to
+      generate these files"
+  ))
+  # nolint end
 }
 
 

--- a/R/utils_atlas.R
+++ b/R/utils_atlas.R
@@ -426,10 +426,13 @@ run_image_steps <- function(
       dilate = dilate,
       skip_existing = config$skip_existing
     )
+    stamp_cache_dir(dirs$processed)
+    stamp_cache_dir(dirs$masks)
     if (config$verbose) cli::cli_progress_done()
   }
 
   if (step_map$extract %in% config$steps) {
+    check_cache_dir(dirs$masks, image_rerun_remedy)
     extract_contours(
       dirs$masks,
       dirs$base,

--- a/R/utils_snapshot.R
+++ b/R/utils_snapshot.R
@@ -105,7 +105,11 @@ process_and_mask_images <- function(
     p()
   }))
 
-  processed_files <- list.files(processed_dir, full.names = TRUE)
+  processed_files <- list.files(
+    processed_dir,
+    full.names = TRUE,
+    pattern = "\\.png$"
+  )
   invisible(lapply(processed_files, function(f) {
     extract_alpha_mask(
       f,

--- a/inst/templates/atlas-fallback/dot-gitignore
+++ b/inst/templates/atlas-fallback/dot-gitignore
@@ -12,3 +12,4 @@ data-raw/**/*.mgz
 *.nii.gz
 *.mgz
 *.mat
+cache_manifest.rds

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -381,3 +381,19 @@ local_fake_fsaverage <- function(
   )
   tmp_dir
 }
+
+
+local_cache_file <- function(
+  content = 1,
+  name = "step.rds",
+  stamped = TRUE,
+  env = parent.frame()
+) {
+  dir <- withr::local_tempdir("cache_", .local_envir = env)
+  file <- file.path(dir, name)
+  saveRDS(content, file)
+  if (stamped) {
+    stamp_cache_files(file)
+  }
+  file
+}

--- a/tests/testthat/test-atlas_cerebellar.R
+++ b/tests/testthat/test-atlas_cerebellar.R
@@ -1724,6 +1724,38 @@ testthat::describe("cerebellar_read_data", {
     expect_true(all(result$deep_data$deep))
   })
 
+  it("aborts when cached deep_data was written by another version", {
+    dirs <- list(base = withr::local_tempdir())
+
+    mock_components <- list(
+      core = data.frame(
+        hemi = "left",
+        region = "I-IV",
+        label = "left_I-IV",
+        stringsAsFactors = FALSE
+      )
+    )
+
+    save_cache_rds(mock_components, file.path(dirs$base, "components.rds"))
+    saveRDS(list(deep = TRUE), file.path(dirs$base, "deep_data.rds"))
+
+    local_mocked_bindings(
+      load_or_run_step = function(...) {
+        list(
+          run = FALSE,
+          data = list("components.rds" = mock_components)
+        )
+      }
+    )
+
+    config <- list(steps = 1L, skip_existing = TRUE, verbose = FALSE)
+
+    expect_error(
+      cerebellar_read_data(config, dirs, read_fn = stop),
+      "deep_data.rds"
+    )
+  })
+
   it("separates deep nuclei from surface data when deep column present", {
     dirs <- list(base = withr::local_tempdir())
 

--- a/tests/testthat/test-atlas_cerebellar.R
+++ b/tests/testthat/test-atlas_cerebellar.R
@@ -1660,7 +1660,7 @@ testthat::describe("cerebellar_read_data", {
     )
     mock_components$vertices_df$vertices <- list(0:3)
 
-    save_cache_rds(mock_components, file.path(dirs$base, "components.rds"))
+    save_cache_rds(dirs$base, components.rds = mock_components)
 
     local_mocked_bindings(
       load_or_run_step = function(step, steps, files, skip_existing, ...) {
@@ -1705,8 +1705,11 @@ testthat::describe("cerebellar_read_data", {
     )
     mock_deep$vertices <- list(integer(0))
 
-    save_cache_rds(mock_components, file.path(dirs$base, "components.rds"))
-    save_cache_rds(mock_deep, file.path(dirs$base, "deep_data.rds"))
+    save_cache_rds(
+      dirs$base,
+      components.rds = mock_components,
+      deep_data.rds = mock_deep
+    )
 
     local_mocked_bindings(
       load_or_run_step = function(...) {
@@ -1736,7 +1739,7 @@ testthat::describe("cerebellar_read_data", {
       )
     )
 
-    save_cache_rds(mock_components, file.path(dirs$base, "components.rds"))
+    save_cache_rds(dirs$base, components.rds = mock_components)
     saveRDS(list(deep = TRUE), file.path(dirs$base, "deep_data.rds"))
 
     local_mocked_bindings(

--- a/tests/testthat/test-atlas_cerebellar.R
+++ b/tests/testthat/test-atlas_cerebellar.R
@@ -1660,7 +1660,7 @@ testthat::describe("cerebellar_read_data", {
     )
     mock_components$vertices_df$vertices <- list(0:3)
 
-    saveRDS(mock_components, file.path(dirs$base, "components.rds"))
+    save_cache_rds(mock_components, file.path(dirs$base, "components.rds"))
 
     local_mocked_bindings(
       load_or_run_step = function(step, steps, files, skip_existing, ...) {
@@ -1705,8 +1705,8 @@ testthat::describe("cerebellar_read_data", {
     )
     mock_deep$vertices <- list(integer(0))
 
-    saveRDS(mock_components, file.path(dirs$base, "components.rds"))
-    saveRDS(mock_deep, file.path(dirs$base, "deep_data.rds"))
+    save_cache_rds(mock_components, file.path(dirs$base, "components.rds"))
+    save_cache_rds(mock_deep, file.path(dirs$base, "deep_data.rds"))
 
     local_mocked_bindings(
       load_or_run_step = function(...) {

--- a/tests/testthat/test-atlas_cortical.R
+++ b/tests/testthat/test-atlas_cortical.R
@@ -360,8 +360,11 @@ testthat::describe("cortical_read_data", {
         vertices = I(list(1:5))
       )
     )
-    save_cache_rds(mock_atlas, file.path(tmp_dir, "atlas_3d.rds"))
-    save_cache_rds(mock_components, file.path(tmp_dir, "components.rds"))
+    save_cache_rds(
+      tmp_dir,
+      atlas_3d.rds = mock_atlas,
+      components.rds = mock_components
+    )
 
     result <- cortical_read_data(
       config = list(steps = 1:2, skip_existing = TRUE, verbose = FALSE),
@@ -697,8 +700,11 @@ testthat::describe("cortical_read_data verbose paths", {
         vertices = I(list(1:5))
       )
     )
-    save_cache_rds(mock_atlas, file.path(tmp_dir, "atlas_3d.rds"))
-    save_cache_rds(mock_components, file.path(tmp_dir, "components.rds"))
+    save_cache_rds(
+      tmp_dir,
+      atlas_3d.rds = mock_atlas,
+      components.rds = mock_components
+    )
 
     expect_messages(
       cortical_read_data(

--- a/tests/testthat/test-atlas_cortical.R
+++ b/tests/testthat/test-atlas_cortical.R
@@ -360,8 +360,8 @@ testthat::describe("cortical_read_data", {
         vertices = I(list(1:5))
       )
     )
-    saveRDS(mock_atlas, file.path(tmp_dir, "atlas_3d.rds"))
-    saveRDS(mock_components, file.path(tmp_dir, "components.rds"))
+    save_cache_rds(mock_atlas, file.path(tmp_dir, "atlas_3d.rds"))
+    save_cache_rds(mock_components, file.path(tmp_dir, "components.rds"))
 
     result <- cortical_read_data(
       config = list(steps = 1:2, skip_existing = TRUE, verbose = FALSE),
@@ -697,8 +697,8 @@ testthat::describe("cortical_read_data verbose paths", {
         vertices = I(list(1:5))
       )
     )
-    saveRDS(mock_atlas, file.path(tmp_dir, "atlas_3d.rds"))
-    saveRDS(mock_components, file.path(tmp_dir, "components.rds"))
+    save_cache_rds(mock_atlas, file.path(tmp_dir, "atlas_3d.rds"))
+    save_cache_rds(mock_components, file.path(tmp_dir, "components.rds"))
 
     expect_messages(
       cortical_read_data(

--- a/tests/testthat/test-atlas_geometry.R
+++ b/tests/testthat/test-atlas_geometry.R
@@ -738,6 +738,9 @@ testthat::describe("make_multipolygon", {
     expect_identical(result$filenm, c("region1", "region2"))
   })
 
+  # The fixture is stamped, so the manifest check passes and the y-axis
+  # guard is what fires. No pipeline writes an unstamped contour file any
+  # more, so this is the only way left to reach that guard.
   it("aborts on contours cached before the y-up convention", {
     contourfile <- save_contours_fixture(
       withr::local_tempfile(fileext = ".rda"),
@@ -1339,5 +1342,30 @@ testthat::describe("smoothness scale", {
 
   it("keeps spline at or above its meaningful floor", {
     expect_gte(native_smoothness(0.01, "spline"), 2)
+  })
+})
+
+
+testthat::describe("contour stage cache staleness", {
+  it("aborts when smooth_contours reads contours from another version", {
+    outdir <- withr::local_tempdir("smooth_stale_")
+    save_contours_fixture(file.path(outdir, "contours.rda"))
+    local_mocked_bindings(cache_format_version = function() 9999L)
+
+    expect_error(
+      smooth_contours(outdir, smoothness = 5, step = "", verbose = FALSE),
+      "Rerun the contour extraction"
+    )
+  })
+
+  it("aborts when reduce_vertex reads contours from another version", {
+    outdir <- withr::local_tempdir("reduce_stale_")
+    save_contours_fixture(file.path(outdir, "contours_smoothed.rda"))
+    local_mocked_bindings(cache_format_version = function() 9999L)
+
+    expect_error(
+      reduce_vertex(outdir, tolerance = 0.5, step = "", verbose = FALSE),
+      "Rerun the contour extraction"
+    )
   })
 })

--- a/tests/testthat/test-atlas_geometry.R
+++ b/tests/testthat/test-atlas_geometry.R
@@ -19,6 +19,7 @@ save_contours_fixture <- function(path, y_axis = "up") {
   )
   contours$y_axis <- y_axis
   save(contours, file = path)
+  stamp_cache_files(path)
   path
 }
 
@@ -63,6 +64,7 @@ testthat::describe("build_contour_sf", {
       )
     )
     save(contours, file = contours_file)
+    stamp_cache_files(contours_file)
 
     slabs <- data.frame(
       name = c("axial_1", "coronal_1"),
@@ -112,6 +114,7 @@ testthat::describe("build_contour_sf", {
       )
     )
     save(contours, file = contours_file)
+    stamp_cache_files(contours_file)
 
     slabs <- data.frame(
       name = c("axial_1", "coronal_1"),
@@ -149,6 +152,7 @@ testthat::describe("build_contour_sf", {
       )
     )
     save(contours, file = contours_file)
+    stamp_cache_files(contours_file)
 
     slabs <- data.frame(
       name = "axial_1",
@@ -191,6 +195,7 @@ testthat::describe("build_contour_sf", {
       )
     )
     save(contours, file = contours_file)
+    stamp_cache_files(contours_file)
 
     slabs <- data.frame(
       name = "axial_1",
@@ -233,6 +238,7 @@ testthat::describe("build_contour_sf", {
       )
     )
     save(contours, file = contours_file)
+    stamp_cache_files(contours_file)
 
     slabs <- data.frame(
       name = "axial_1",
@@ -626,6 +632,7 @@ testthat::describe("smooth_contours", {
       )
     )
     save(contours, file = file.path(outdir, "contours.rda"))
+    stamp_cache_files(file.path(outdir, "contours.rda"))
 
     result <- smooth_contours(outdir, smoothness = 5, step = "")
 
@@ -641,6 +648,7 @@ testthat::describe("smooth_contours", {
       geometry = sf::st_sfc(sf::st_polygon())
     )
     save(contours, file = file.path(outdir, "contours.rda"))
+    stamp_cache_files(file.path(outdir, "contours.rda"))
 
     expect_warning(
       {
@@ -683,6 +691,7 @@ testthat::describe("reduce_vertex", {
       geometry = sf::st_sfc(sf::st_polygon(list(coords)))
     )
     save(contours, file = file.path(outdir, "contours_smoothed.rda"))
+    stamp_cache_files(file.path(outdir, "contours_smoothed.rda"))
 
     result <- reduce_vertex(outdir, tolerance = 0.5, step = "")
 
@@ -702,6 +711,7 @@ testthat::describe("reduce_vertex", {
       geometry = sf::st_sfc(sf::st_polygon())
     )
     save(contours, file = file.path(outdir, "contours_smoothed.rda"))
+    stamp_cache_files(file.path(outdir, "contours_smoothed.rda"))
 
     expect_warning(
       {
@@ -736,6 +746,15 @@ testthat::describe("make_multipolygon", {
 
     expect_error(make_multipolygon(contourfile), "older ggseg.extra")
   })
+
+  it("aborts on contours cached by an older cache format version", {
+    contourfile <- save_contours_fixture(
+      withr::local_tempfile(fileext = ".rda")
+    )
+    local_mocked_bindings(cache_format_version = function() 9999L)
+
+    expect_error(make_multipolygon(contourfile), "written by an older")
+  })
 })
 
 
@@ -754,6 +773,7 @@ testthat::describe("smooth_contours verbose output", {
       )
     )
     save(contours, file = file.path(outdir, "contours.rda"))
+    stamp_cache_files(file.path(outdir, "contours.rda"))
 
     expect_no_message(
       smooth_contours(outdir, smoothness = 5, step = "1/3", verbose = TRUE)
@@ -777,6 +797,7 @@ testthat::describe("reduce_vertex verbose output", {
       )
     )
     save(contours, file = file.path(outdir, "contours_smoothed.rda"))
+    stamp_cache_files(file.path(outdir, "contours_smoothed.rda"))
 
     expect_no_message(
       reduce_vertex(outdir, tolerance = 0.5, step = "2/3", verbose = TRUE)

--- a/tests/testthat/test-atlas_geometry.R
+++ b/tests/testthat/test-atlas_geometry.R
@@ -5,7 +5,7 @@ skip_without_mask_io <- function() {
   testthat::skip_if_not_installed("terra")
 }
 
-save_contours_fixture <- function(path, y_axis = "up") {
+save_contours_fixture <- function(path, y_axis = "up", contours = NULL) {
   square <- function(x0) {
     sf::st_polygon(list(matrix(
       c(x0, 0, x0 + 1, 0, x0 + 1, 1, x0, 1, x0, 0),
@@ -13,11 +13,13 @@ save_contours_fixture <- function(path, y_axis = "up") {
       byrow = TRUE
     )))
   }
-  contours <- sf::st_sf(
-    filenm = c("region1", "region1", "region2"),
-    geometry = sf::st_sfc(square(0), square(2), square(4))
-  )
-  contours$y_axis <- y_axis
+  if (is.null(contours)) {
+    contours <- sf::st_sf(
+      filenm = c("region1", "region1", "region2"),
+      geometry = sf::st_sfc(square(0), square(2), square(4))
+    )
+    contours$y_axis <- y_axis
+  }
   save(contours, file = path)
   stamp_cache_files(path)
   path
@@ -63,8 +65,7 @@ testthat::describe("build_contour_sf", {
         )))
       )
     )
-    save(contours, file = contours_file)
-    stamp_cache_files(contours_file)
+    save_contours_fixture(contours_file, contours = contours)
 
     slabs <- data.frame(
       name = c("axial_1", "coronal_1"),
@@ -113,8 +114,7 @@ testthat::describe("build_contour_sf", {
         )))
       )
     )
-    save(contours, file = contours_file)
-    stamp_cache_files(contours_file)
+    save_contours_fixture(contours_file, contours = contours)
 
     slabs <- data.frame(
       name = c("axial_1", "coronal_1"),
@@ -151,8 +151,7 @@ testthat::describe("build_contour_sf", {
         )))
       )
     )
-    save(contours, file = contours_file)
-    stamp_cache_files(contours_file)
+    save_contours_fixture(contours_file, contours = contours)
 
     slabs <- data.frame(
       name = "axial_1",
@@ -194,8 +193,7 @@ testthat::describe("build_contour_sf", {
         )))
       )
     )
-    save(contours, file = contours_file)
-    stamp_cache_files(contours_file)
+    save_contours_fixture(contours_file, contours = contours)
 
     slabs <- data.frame(
       name = "axial_1",
@@ -237,8 +235,7 @@ testthat::describe("build_contour_sf", {
         )))
       )
     )
-    save(contours, file = contours_file)
-    stamp_cache_files(contours_file)
+    save_contours_fixture(contours_file, contours = contours)
 
     slabs <- data.frame(
       name = "axial_1",
@@ -631,8 +628,10 @@ testthat::describe("smooth_contours", {
         )))
       )
     )
-    save(contours, file = file.path(outdir, "contours.rda"))
-    stamp_cache_files(file.path(outdir, "contours.rda"))
+    save_contours_fixture(
+      file.path(outdir, "contours.rda"),
+      contours = contours
+    )
 
     result <- smooth_contours(outdir, smoothness = 5, step = "")
 
@@ -647,8 +646,10 @@ testthat::describe("smooth_contours", {
       filenm = "test",
       geometry = sf::st_sfc(sf::st_polygon())
     )
-    save(contours, file = file.path(outdir, "contours.rda"))
-    stamp_cache_files(file.path(outdir, "contours.rda"))
+    save_contours_fixture(
+      file.path(outdir, "contours.rda"),
+      contours = contours
+    )
 
     expect_warning(
       {
@@ -690,8 +691,10 @@ testthat::describe("reduce_vertex", {
       region = "test",
       geometry = sf::st_sfc(sf::st_polygon(list(coords)))
     )
-    save(contours, file = file.path(outdir, "contours_smoothed.rda"))
-    stamp_cache_files(file.path(outdir, "contours_smoothed.rda"))
+    save_contours_fixture(
+      file.path(outdir, "contours_smoothed.rda"),
+      contours = contours
+    )
 
     result <- reduce_vertex(outdir, tolerance = 0.5, step = "")
 
@@ -710,8 +713,10 @@ testthat::describe("reduce_vertex", {
       filenm = "test",
       geometry = sf::st_sfc(sf::st_polygon())
     )
-    save(contours, file = file.path(outdir, "contours_smoothed.rda"))
-    stamp_cache_files(file.path(outdir, "contours_smoothed.rda"))
+    save_contours_fixture(
+      file.path(outdir, "contours_smoothed.rda"),
+      contours = contours
+    )
 
     expect_warning(
       {
@@ -756,7 +761,7 @@ testthat::describe("make_multipolygon", {
     )
     local_mocked_bindings(cache_format_version = function() 9999L)
 
-    expect_error(make_multipolygon(contourfile), "written by an older")
+    expect_error(make_multipolygon(contourfile), "written by cache format")
   })
 })
 
@@ -775,8 +780,10 @@ testthat::describe("smooth_contours verbose output", {
         )))
       )
     )
-    save(contours, file = file.path(outdir, "contours.rda"))
-    stamp_cache_files(file.path(outdir, "contours.rda"))
+    save_contours_fixture(
+      file.path(outdir, "contours.rda"),
+      contours = contours
+    )
 
     expect_no_message(
       smooth_contours(outdir, smoothness = 5, step = "1/3", verbose = TRUE)
@@ -799,8 +806,10 @@ testthat::describe("reduce_vertex verbose output", {
         )))
       )
     )
-    save(contours, file = file.path(outdir, "contours_smoothed.rda"))
-    stamp_cache_files(file.path(outdir, "contours_smoothed.rda"))
+    save_contours_fixture(
+      file.path(outdir, "contours_smoothed.rda"),
+      contours = contours
+    )
 
     expect_no_message(
       reduce_vertex(outdir, tolerance = 0.5, step = "2/3", verbose = TRUE)

--- a/tests/testthat/test-cache_version.R
+++ b/tests/testthat/test-cache_version.R
@@ -7,13 +7,24 @@ testthat::describe("stamp_cache_files", {
     stamp_cache_files(file)
 
     manifest <- read_cache_manifest(dir)
+    expect_identical(manifest$file, "components.rds")
+    expect_identical(as.integer(manifest$version), cache_format_version())
+  })
+
+  it("records the modification time of each stamped file", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    saveRDS(list(a = 1), file)
+
+    stamp_cache_files(file)
+
     expect_identical(
-      manifest[["components.rds"]],
-      cache_format_version()
+      read_cache_manifest(dir)$mtime,
+      as.numeric(file.mtime(file))
     )
   })
 
-  it("keeps stamps for files in the same directory", {
+  it("keeps stamps for other files in the same directory", {
     dir <- withr::local_tempdir("cache_")
     first <- file.path(dir, "first.rds")
     second <- file.path(dir, "second.rds")
@@ -24,9 +35,20 @@ testthat::describe("stamp_cache_files", {
     stamp_cache_files(second)
 
     expect_identical(
-      sort(names(read_cache_manifest(dir))),
+      sort(read_cache_manifest(dir)$file),
       c("first.rds", "second.rds")
     )
+  })
+
+  it("replaces rather than duplicates an existing stamp", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    saveRDS(1, file)
+
+    stamp_cache_files(file)
+    stamp_cache_files(file)
+
+    expect_identical(nrow(read_cache_manifest(dir)), 1L)
   })
 
   it("stamps files across several directories at once", {
@@ -40,28 +62,64 @@ testthat::describe("stamp_cache_files", {
 
     expect_identical(stale_cache_files(files), character())
   })
+
+  it("leaves no staging file behind", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    saveRDS(1, file)
+
+    stamp_cache_files(file)
+
+    expect_identical(
+      sort(list.files(dir)),
+      c("cache_manifest.rds", "step.rds")
+    )
+  })
 })
 
 
 testthat::describe("read_cache_manifest", {
-  it("returns an empty vector when no manifest exists", {
+  it("returns an empty manifest when none exists", {
     dir <- withr::local_tempdir("cache_")
 
-    expect_identical(read_cache_manifest(dir), integer())
+    expect_identical(nrow(read_cache_manifest(dir)), 0L)
   })
 
-  it("ignores a manifest that is not a named integer vector", {
+  it("ignores a manifest that is not a manifest table", {
     dir <- withr::local_tempdir("cache_")
     saveRDS(list("not a manifest"), cache_manifest_file(dir))
 
-    expect_identical(read_cache_manifest(dir), integer())
+    expect_identical(nrow(read_cache_manifest(dir)), 0L)
   })
 
-  it("ignores an unreadable manifest", {
+  it("ignores a manifest missing the expected columns", {
     dir <- withr::local_tempdir("cache_")
-    writeLines("not an rds file", cache_manifest_file(dir))
+    saveRDS(data.frame(file = "step.rds"), cache_manifest_file(dir))
 
-    expect_identical(read_cache_manifest(dir), integer())
+    expect_identical(nrow(read_cache_manifest(dir)), 0L)
+  })
+
+  it("ignores a truncated manifest, marking everything stale", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    save_cache_rds(1, file)
+    writeLines("truncated", cache_manifest_file(dir))
+
+    expect_identical(nrow(read_cache_manifest(dir)), 0L)
+    expect_identical(stale_cache_files(file), file)
+  })
+})
+
+
+testthat::describe("write_cache_manifest", {
+  it("warns when the manifest cannot be moved into place", {
+    dir <- withr::local_tempdir("cache_")
+    local_mocked_bindings(file.rename = function(...) FALSE, .package = "base")
+
+    expect_warning(
+      write_cache_manifest(dir, empty_cache_manifest()),
+      "cache manifest"
+    )
   })
 })
 
@@ -97,6 +155,16 @@ testthat::describe("stale_cache_files", {
     expect_identical(stale_cache_files(file), file)
   })
 
+  it("reports a file rewritten after stamping as stale", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    save_cache_rds(1, file)
+
+    Sys.setFileTime(file, Sys.time() + 5)
+
+    expect_identical(stale_cache_files(file), file)
+  })
+
   it("returns only the stale members of a mixed set", {
     dir <- withr::local_tempdir("cache_")
     fresh <- file.path(dir, "fresh.rds")
@@ -105,6 +173,40 @@ testthat::describe("stale_cache_files", {
     saveRDS(2, old)
 
     expect_identical(stale_cache_files(c(fresh, old)), old)
+  })
+})
+
+
+testthat::describe("stale_cache_origin", {
+  it("names an older ggseg.extra for unstamped files", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    saveRDS(1, file)
+
+    expect_identical(stale_cache_origin(file), "an older ggseg.extra")
+  })
+
+  it("names a newer ggseg.extra for stamps ahead of this version", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    save_cache_rds(1, file)
+    local_mocked_bindings(cache_format_version = function() 0L)
+
+    expect_identical(stale_cache_origin(file), "a newer ggseg.extra")
+  })
+
+  it("stays vague when the stale files disagree", {
+    dir <- withr::local_tempdir("cache_")
+    ahead <- file.path(dir, "ahead.rds")
+    unstamped <- file.path(dir, "unstamped.rds")
+    save_cache_rds(1, ahead)
+    saveRDS(2, unstamped)
+    local_mocked_bindings(cache_format_version = function() 0L)
+
+    expect_identical(
+      stale_cache_origin(c(ahead, unstamped)),
+      "a different version of ggseg.extra"
+    )
   })
 })
 
@@ -126,6 +228,18 @@ testthat::describe("check_cache_current", {
     expect_error(
       check_cache_current(file, "Rerun the contour extraction steps"),
       "Rerun the contour extraction steps"
+    )
+  })
+
+  it("says the cache is newer when it was written ahead of this version", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    save_cache_rds(1, file)
+    local_mocked_bindings(cache_format_version = function() 0L)
+
+    expect_error(
+      check_cache_current(file, "Rerun step 1"),
+      "a newer ggseg.extra"
     )
   })
 })

--- a/tests/testthat/test-cache_version.R
+++ b/tests/testthat/test-cache_version.R
@@ -1,54 +1,32 @@
 testthat::describe("stamp_cache_files", {
   it("records the current format version for each stamped file", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "components.rds")
-    saveRDS(list(a = 1), file)
-
-    stamp_cache_files(file)
-
-    manifest <- read_cache_manifest(dir)
-    expect_identical(manifest$file, "components.rds")
-    expect_identical(as.integer(manifest$version), cache_format_version())
-  })
-
-  it("records the modification time of each stamped file", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    saveRDS(list(a = 1), file)
-
-    stamp_cache_files(file)
+    file <- local_cache_file(name = "components.rds")
 
     expect_identical(
-      read_cache_manifest(dir)$mtime,
-      as.numeric(file.mtime(file))
+      read_cache_manifest(dirname(file))[["components.rds"]],
+      cache_format_version()
     )
   })
 
   it("keeps stamps for other files in the same directory", {
-    dir <- withr::local_tempdir("cache_")
-    first <- file.path(dir, "first.rds")
-    second <- file.path(dir, "second.rds")
-    saveRDS(1, first)
+    first <- local_cache_file(name = "first.rds")
+    second <- file.path(dirname(first), "second.rds")
     saveRDS(2, second)
 
-    stamp_cache_files(first)
     stamp_cache_files(second)
 
     expect_identical(
-      sort(read_cache_manifest(dir)$file),
+      sort(names(read_cache_manifest(dirname(first)))),
       c("first.rds", "second.rds")
     )
   })
 
   it("replaces rather than duplicates an existing stamp", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    saveRDS(1, file)
+    file <- local_cache_file()
 
     stamp_cache_files(file)
-    stamp_cache_files(file)
 
-    expect_identical(nrow(read_cache_manifest(dir)), 1L)
+    expect_length(read_cache_manifest(dirname(file)), 1L)
   })
 
   it("stamps files across several directories at once", {
@@ -64,15 +42,31 @@ testthat::describe("stamp_cache_files", {
   })
 
   it("leaves no staging file behind", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    saveRDS(1, file)
-
-    stamp_cache_files(file)
+    file <- local_cache_file()
 
     expect_identical(
-      sort(list.files(dir)),
+      sort(list.files(dirname(file))),
       c("cache_manifest.rds", "step.rds")
+    )
+  })
+})
+
+
+testthat::describe("stamp_cache_dir", {
+  it("marks a stamped directory current", {
+    dir <- withr::local_tempdir("cache_")
+
+    stamp_cache_dir(dir)
+
+    expect_identical(check_cache_dir(dir, "Rerun the image step"), dir)
+  })
+
+  it("aborts for a directory no ggseg.extra stamped", {
+    dir <- withr::local_tempdir("cache_")
+
+    expect_error(
+      check_cache_dir(dir, "Rerun the image-processing step"),
+      "Rerun the image-processing step"
     )
   })
 })
@@ -82,30 +76,21 @@ testthat::describe("read_cache_manifest", {
   it("returns an empty manifest when none exists", {
     dir <- withr::local_tempdir("cache_")
 
-    expect_identical(nrow(read_cache_manifest(dir)), 0L)
+    expect_identical(read_cache_manifest(dir), integer())
   })
 
-  it("ignores a manifest that is not a manifest table", {
+  it("ignores a manifest that is not a name-to-version vector", {
     dir <- withr::local_tempdir("cache_")
     saveRDS(list("not a manifest"), cache_manifest_file(dir))
 
-    expect_identical(nrow(read_cache_manifest(dir)), 0L)
-  })
-
-  it("ignores a manifest missing the expected columns", {
-    dir <- withr::local_tempdir("cache_")
-    saveRDS(data.frame(file = "step.rds"), cache_manifest_file(dir))
-
-    expect_identical(nrow(read_cache_manifest(dir)), 0L)
+    expect_identical(read_cache_manifest(dir), integer())
   })
 
   it("ignores a truncated manifest, marking everything stale", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    save_cache_rds(1, file)
-    writeLines("truncated", cache_manifest_file(dir))
+    file <- local_cache_file()
+    writeLines("truncated", cache_manifest_file(dirname(file)))
 
-    expect_identical(nrow(read_cache_manifest(dir)), 0L)
+    expect_identical(read_cache_manifest(dirname(file)), integer())
     expect_identical(stale_cache_files(file), file)
   })
 })
@@ -117,7 +102,7 @@ testthat::describe("write_cache_manifest", {
     local_mocked_bindings(file.rename = function(...) FALSE, .package = "base")
 
     expect_warning(
-      write_cache_manifest(dir, empty_cache_manifest()),
+      write_cache_manifest(dir, c(step.rds = cache_format_version())),
       "cache manifest"
     )
   })
@@ -125,51 +110,91 @@ testthat::describe("write_cache_manifest", {
 
 
 testthat::describe("save_cache_rds", {
-  it("saves the object and stamps it in one step", {
+  it("writes each object to its named file and stamps it", {
     dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
 
-    save_cache_rds(list(a = 1), file)
+    files <- save_cache_rds(dir, first.rds = list(a = 1), second.rds = 2)
 
-    expect_identical(readRDS(file), list(a = 1))
-    expect_identical(stale_cache_files(file), character())
+    expect_identical(readRDS(files[1]), list(a = 1))
+    expect_identical(stale_cache_files(files), character())
+  })
+
+  it("writes the manifest once for a batch of files", {
+    dir <- withr::local_tempdir("cache_")
+    writes <- new.env()
+    writes$n <- 0L
+    local_mocked_bindings(
+      write_cache_manifest = function(dir, manifest) {
+        writes$n <- writes$n + 1L
+        invisible(NULL)
+      }
+    )
+
+    save_cache_rds(dir, first.rds = 1, second.rds = 2)
+
+    expect_identical(writes$n, 1L)
+  })
+})
+
+
+testthat::describe("save_cache_rda", {
+  it("round-trips contours through a stamped cache", {
+    dir <- withr::local_tempdir("cache_")
+    contours <- mock_sf_polygon()
+    loaded <- new.env()
+
+    file <- save_cache_rda(contours, dir, "contours.rda")
+    load_cached_rda(file, "Rerun the contour steps", envir = loaded)
+
+    expect_s3_class(loaded$contours, "sf")
+  })
+})
+
+
+testthat::describe("load_cached_rda", {
+  it("rejects a stale cache before deserializing it", {
+    dir <- withr::local_tempdir("cache_")
+    file <- save_cache_rda(mock_sf_polygon(), dir, "contours.rda")
+    local_mocked_bindings(cache_format_version = function() 9999L)
+
+    expect_error(
+      load_cached_rda(file, "Rerun the contour steps", envir = new.env()),
+      "Rerun the contour steps"
+    )
+  })
+
+  it("still reports a missing file as missing", {
+    dir <- withr::local_tempdir("cache_")
+
+    expect_error(
+      load_cached_rda(
+        file.path(dir, "absent.rda"),
+        "Rerun the contour steps",
+        envir = new.env()
+      ),
+      "not found"
+    )
   })
 })
 
 
 testthat::describe("stale_cache_files", {
   it("reports unstamped files as stale", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    saveRDS(1, file)
+    file <- local_cache_file(stamped = FALSE)
 
     expect_identical(stale_cache_files(file), file)
   })
 
   it("reports files stamped by another format version as stale", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    save_cache_rds(1, file)
+    file <- local_cache_file()
     local_mocked_bindings(cache_format_version = function() 9999L)
 
     expect_identical(stale_cache_files(file), file)
   })
 
-  it("reports a file rewritten after stamping as stale", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    save_cache_rds(1, file)
-
-    Sys.setFileTime(file, Sys.time() + 5)
-
-    expect_identical(stale_cache_files(file), file)
-  })
-
   it("returns only the stale members of a mixed set", {
-    dir <- withr::local_tempdir("cache_")
-    fresh <- file.path(dir, "fresh.rds")
-    old <- file.path(dir, "old.rds")
-    save_cache_rds(1, fresh)
+    fresh <- local_cache_file(name = "fresh.rds")
+    old <- file.path(dirname(fresh), "old.rds")
     saveRDS(2, old)
 
     expect_identical(stale_cache_files(c(fresh, old)), old)
@@ -177,83 +202,36 @@ testthat::describe("stale_cache_files", {
 })
 
 
-testthat::describe("stale_cache_origin", {
-  it("names an older ggseg.extra for unstamped files", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    saveRDS(1, file)
-
-    expect_identical(stale_cache_origin(file), "an older ggseg.extra")
-  })
-
-  it("names a newer ggseg.extra for stamps ahead of this version", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    save_cache_rds(1, file)
-    local_mocked_bindings(cache_format_version = function() 0L)
-
-    expect_identical(stale_cache_origin(file), "a newer ggseg.extra")
-  })
-
-  it("stays vague when the stale files disagree", {
-    dir <- withr::local_tempdir("cache_")
-    ahead <- file.path(dir, "ahead.rds")
-    unstamped <- file.path(dir, "unstamped.rds")
-    save_cache_rds(1, ahead)
-    saveRDS(2, unstamped)
-    local_mocked_bindings(cache_format_version = function() 0L)
-
-    expect_identical(
-      stale_cache_origin(c(ahead, unstamped)),
-      "a different version of ggseg.extra"
-    )
-  })
-})
-
-
 testthat::describe("check_cache_current", {
   it("passes stamped files through unchanged", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    save_cache_rds(1, file)
+    file <- local_cache_file()
 
     expect_identical(check_cache_current(file, "Rerun step 1"), file)
   })
 
-  it("aborts with the given remedy for a stale file", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    saveRDS(1, file)
-
-    expect_error(
-      check_cache_current(file, "Rerun the contour extraction steps"),
-      "Rerun the contour extraction steps"
-    )
-  })
-
-  it("says the cache is newer when it was written ahead of this version", {
-    dir <- withr::local_tempdir("cache_")
-    file <- file.path(dir, "step.rds")
-    save_cache_rds(1, file)
-    local_mocked_bindings(cache_format_version = function() 0L)
+  it("reports an unstamped cache as having no format version", {
+    file <- local_cache_file(stamped = FALSE)
 
     expect_error(
       check_cache_current(file, "Rerun step 1"),
-      "a newer ggseg.extra"
+      "written by cache format none"
+    )
+  })
+
+  it("names both the found and the expected format version", {
+    file <- local_cache_file()
+    local_mocked_bindings(cache_format_version = function() 9999L)
+
+    expect_error(
+      check_cache_current(file, "Rerun step 1"),
+      "written by cache format 1"
     )
   })
 })
 
 
-testthat::describe("abort_stale_step_cache", {
-  it("names the step to rerun", {
-    expect_error(
-      abort_stale_step_cache(
-        "atlas_data.rds",
-        1L,
-        "Step 1 (Project to surface)"
-      ),
-      "Include step 1"
-    )
+testthat::describe("step_rerun_remedy", {
+  it("names the step to include", {
+    expect_match(step_rerun_remedy(3L), "Include step 3")
   })
 })

--- a/tests/testthat/test-cache_version.R
+++ b/tests/testthat/test-cache_version.R
@@ -1,0 +1,145 @@
+testthat::describe("stamp_cache_files", {
+  it("records the current format version for each stamped file", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "components.rds")
+    saveRDS(list(a = 1), file)
+
+    stamp_cache_files(file)
+
+    manifest <- read_cache_manifest(dir)
+    expect_identical(
+      manifest[["components.rds"]],
+      cache_format_version()
+    )
+  })
+
+  it("keeps stamps for files in the same directory", {
+    dir <- withr::local_tempdir("cache_")
+    first <- file.path(dir, "first.rds")
+    second <- file.path(dir, "second.rds")
+    saveRDS(1, first)
+    saveRDS(2, second)
+
+    stamp_cache_files(first)
+    stamp_cache_files(second)
+
+    expect_identical(
+      sort(names(read_cache_manifest(dir))),
+      c("first.rds", "second.rds")
+    )
+  })
+
+  it("stamps files across several directories at once", {
+    base <- withr::local_tempdir("cache_")
+    dirs <- file.path(base, c("one", "two"))
+    invisible(lapply(dirs, dir.create))
+    files <- file.path(dirs, "step.rds")
+    invisible(lapply(files, function(f) saveRDS(1, f)))
+
+    stamp_cache_files(files)
+
+    expect_identical(stale_cache_files(files), character())
+  })
+})
+
+
+testthat::describe("read_cache_manifest", {
+  it("returns an empty vector when no manifest exists", {
+    dir <- withr::local_tempdir("cache_")
+
+    expect_identical(read_cache_manifest(dir), integer())
+  })
+
+  it("ignores a manifest that is not a named integer vector", {
+    dir <- withr::local_tempdir("cache_")
+    saveRDS(list("not a manifest"), cache_manifest_file(dir))
+
+    expect_identical(read_cache_manifest(dir), integer())
+  })
+
+  it("ignores an unreadable manifest", {
+    dir <- withr::local_tempdir("cache_")
+    writeLines("not an rds file", cache_manifest_file(dir))
+
+    expect_identical(read_cache_manifest(dir), integer())
+  })
+})
+
+
+testthat::describe("save_cache_rds", {
+  it("saves the object and stamps it in one step", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+
+    save_cache_rds(list(a = 1), file)
+
+    expect_identical(readRDS(file), list(a = 1))
+    expect_identical(stale_cache_files(file), character())
+  })
+})
+
+
+testthat::describe("stale_cache_files", {
+  it("reports unstamped files as stale", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    saveRDS(1, file)
+
+    expect_identical(stale_cache_files(file), file)
+  })
+
+  it("reports files stamped by another format version as stale", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    save_cache_rds(1, file)
+    local_mocked_bindings(cache_format_version = function() 9999L)
+
+    expect_identical(stale_cache_files(file), file)
+  })
+
+  it("returns only the stale members of a mixed set", {
+    dir <- withr::local_tempdir("cache_")
+    fresh <- file.path(dir, "fresh.rds")
+    old <- file.path(dir, "old.rds")
+    save_cache_rds(1, fresh)
+    saveRDS(2, old)
+
+    expect_identical(stale_cache_files(c(fresh, old)), old)
+  })
+})
+
+
+testthat::describe("check_cache_current", {
+  it("passes stamped files through unchanged", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    save_cache_rds(1, file)
+
+    expect_identical(check_cache_current(file, "Rerun step 1"), file)
+  })
+
+  it("aborts with the given remedy for a stale file", {
+    dir <- withr::local_tempdir("cache_")
+    file <- file.path(dir, "step.rds")
+    saveRDS(1, file)
+
+    expect_error(
+      check_cache_current(file, "Rerun the contour extraction steps"),
+      "Rerun the contour extraction steps"
+    )
+  })
+})
+
+
+testthat::describe("abort_stale_step_cache", {
+  it("names the step to rerun", {
+    expect_error(
+      abort_stale_step_cache(
+        "atlas_data.rds",
+        1L,
+        "Step 1 (Project to surface)"
+      ),
+      "Include step 1"
+    )
+  })
+})

--- a/tests/testthat/test-subcortical_steps.R
+++ b/tests/testthat/test-subcortical_steps.R
@@ -957,12 +957,8 @@ testthat::describe("run_image_steps (subcort step_map)", {
       smoothness = 3,
       tolerance = 0.5
     )
-    dirs <- list(
-      snapshots = withr::local_tempdir(),
-      processed = withr::local_tempdir(),
-      masks = withr::local_tempdir(),
-      base = withr::local_tempdir()
-    )
+    dirs <- mock_dirs()
+    stamp_cache_dir(dirs$masks)
 
     run_image_steps(config, dirs, subcort_step_map, 9L)
 
@@ -1004,12 +1000,8 @@ testthat::describe("run_image_steps (subcort step_map)", {
       smoothness = 3,
       tolerance = 0.5
     )
-    dirs <- list(
-      snapshots = withr::local_tempdir(),
-      processed = withr::local_tempdir(),
-      masks = withr::local_tempdir(),
-      base = withr::local_tempdir()
-    )
+    dirs <- mock_dirs()
+    stamp_cache_dir(dirs$masks)
 
     run_image_steps(config, dirs, subcort_step_map, 9L)
 
@@ -1017,6 +1009,53 @@ testthat::describe("run_image_steps (subcort step_map)", {
     expect_true(.cap$step6_called)
     expect_false(.cap$step7_called)
     expect_true(.cap$step8_called)
+  })
+
+  it("stamps the processed and mask directories after processing", {
+    local_mocked_bindings(
+      process_and_mask_images = function(...) invisible(NULL),
+      extract_contours = function(...) invisible(NULL),
+      smooth_contours = function(...) invisible(NULL),
+      reduce_vertex = function(...) invisible(NULL)
+    )
+
+    config <- list(
+      steps = 5L:8L,
+      verbose = FALSE,
+      skip_existing = FALSE,
+      smoothness = 3,
+      tolerance = 0.5
+    )
+    dirs <- mock_dirs()
+
+    run_image_steps(config, dirs, subcort_step_map, 9L)
+
+    expect_identical(
+      read_cache_manifest(dirs$masks)[["."]],
+      cache_format_version()
+    )
+    expect_identical(
+      read_cache_manifest(dirs$processed)[["."]],
+      cache_format_version()
+    )
+  })
+
+  it("aborts before extracting contours from masks another version made", {
+    local_mocked_bindings(extract_contours = function(...) invisible(NULL))
+
+    config <- list(
+      steps = 6L,
+      verbose = FALSE,
+      skip_existing = FALSE,
+      smoothness = 3,
+      tolerance = 0.5
+    )
+    dirs <- mock_dirs()
+
+    expect_error(
+      run_image_steps(config, dirs, subcort_step_map, 9L),
+      "Rerun the image-processing step"
+    )
   })
 })
 

--- a/tests/testthat/test-tract_steps.R
+++ b/tests/testthat/test-tract_steps.R
@@ -1043,7 +1043,8 @@ testthat::describe("run_image_steps (tract step_map)", {
     )
 
     config <- list(steps = 3L, verbose = FALSE, skip_existing = FALSE)
-    dirs <- list(snapshots = "s", processed = "p", masks = "m", base = "b")
+    dirs <- mock_dirs()
+    stamp_cache_dir(dirs$masks)
 
     run_image_steps(config, dirs, tract_step_map, 7L)
 
@@ -1060,7 +1061,8 @@ testthat::describe("run_image_steps (tract step_map)", {
     )
 
     config <- list(steps = 4L, verbose = FALSE)
-    dirs <- list(snapshots = "s", processed = "p", masks = "m", base = "b")
+    dirs <- mock_dirs()
+    stamp_cache_dir(dirs$masks)
 
     run_image_steps(config, dirs, tract_step_map, 7L)
 
@@ -1077,7 +1079,8 @@ testthat::describe("run_image_steps (tract step_map)", {
     )
 
     config <- list(steps = 5L, verbose = FALSE, smoothness = 1.0)
-    dirs <- list(snapshots = "s", processed = "p", masks = "m", base = "b")
+    dirs <- mock_dirs()
+    stamp_cache_dir(dirs$masks)
 
     run_image_steps(config, dirs, tract_step_map, 7L)
 
@@ -1094,7 +1097,8 @@ testthat::describe("run_image_steps (tract step_map)", {
     )
 
     config <- list(steps = 6L, verbose = FALSE, tolerance = 0.01)
-    dirs <- list(snapshots = "s", processed = "p", masks = "m", base = "b")
+    dirs <- mock_dirs()
+    stamp_cache_dir(dirs$masks)
 
     run_image_steps(config, dirs, tract_step_map, 7L)
 
@@ -1129,7 +1133,8 @@ testthat::describe("run_image_steps (tract step_map)", {
       smoothness = 1.0,
       tolerance = 0.01
     )
-    dirs <- list(snapshots = "s", processed = "p", masks = "m", base = "b")
+    dirs <- mock_dirs()
+    stamp_cache_dir(dirs$masks)
 
     run_image_steps(config, dirs, tract_step_map, 7L)
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -257,7 +257,7 @@ testthat::describe("load_or_run_step", {
 
   it("loads data when files exist and skip_existing=TRUE", {
     tmp <- withr::local_tempfile(fileext = ".rds")
-    saveRDS(list(a = 1), tmp)
+    save_cache_rds(list(a = 1), tmp)
 
     result <- load_or_run_step(
       1L,
@@ -286,7 +286,7 @@ testthat::describe("load_or_run_step", {
 
   it("loads data when step not requested but files exist", {
     tmp <- withr::local_tempfile(fileext = ".rds")
-    saveRDS(list(b = 2), tmp)
+    save_cache_rds(list(b = 2), tmp)
 
     result <- load_or_run_step(
       1L,
@@ -298,6 +298,41 @@ testthat::describe("load_or_run_step", {
 
     expect_false(result$run)
     expect_identical(result$data[[1]], list(b = 2))
+  })
+
+  it("aborts when a cache predates the format version and step is not run", {
+    tmp <- withr::local_tempfile(fileext = ".rds")
+    saveRDS(list(a = 1), tmp)
+
+    expect_error(
+      load_or_run_step(
+        1L,
+        2L:3L,
+        files = tmp,
+        skip_existing = TRUE,
+        step_name = "Step 1 (Project to surface)"
+      ),
+      "older ggseg.extra"
+    )
+  })
+
+  it("recomputes a stale cache when its step was requested", {
+    tmp <- withr::local_tempfile(fileext = ".rds")
+    saveRDS(list(a = 1), tmp)
+
+    result <- expect_messages(
+      load_or_run_step(
+        1L,
+        1L:3L,
+        files = tmp,
+        skip_existing = TRUE,
+        step_name = "Step 1"
+      ),
+      "recomputing"
+    )
+
+    expect_true(result$run)
+    expect_null(result$data)
   })
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -256,8 +256,7 @@ testthat::describe("load_or_run_step", {
   })
 
   it("loads data when files exist and skip_existing=TRUE", {
-    tmp <- withr::local_tempfile(fileext = ".rds")
-    save_cache_rds(list(a = 1), tmp)
+    tmp <- local_cache_file(list(a = 1))
 
     result <- load_or_run_step(
       1L,
@@ -285,8 +284,7 @@ testthat::describe("load_or_run_step", {
   })
 
   it("loads data when step not requested but files exist", {
-    tmp <- withr::local_tempfile(fileext = ".rds")
-    save_cache_rds(list(b = 2), tmp)
+    tmp <- local_cache_file(list(b = 2))
 
     result <- load_or_run_step(
       1L,
@@ -301,8 +299,7 @@ testthat::describe("load_or_run_step", {
   })
 
   it("aborts when a cache predates the format version and step is not run", {
-    tmp <- withr::local_tempfile(fileext = ".rds")
-    saveRDS(list(a = 1), tmp)
+    tmp <- local_cache_file(list(a = 1), stamped = FALSE)
 
     expect_error(
       load_or_run_step(
@@ -312,13 +309,12 @@ testthat::describe("load_or_run_step", {
         skip_existing = TRUE,
         step_name = "Step 1 (Project to surface)"
       ),
-      "older ggseg.extra"
+      "Include step 1"
     )
   })
 
   it("recomputes a stale cache when its step was requested", {
-    tmp <- withr::local_tempfile(fileext = ".rds")
-    saveRDS(list(a = 1), tmp)
+    tmp <- local_cache_file(list(a = 1), stamped = FALSE)
 
     result <- expect_messages(
       load_or_run_step(


### PR DESCRIPTION
## Summary

Closes #142.

Rebuilding ggsegMiccai after #137 silently produced the **old, broken** atlas. `data-raw/make_atlas.R` passes `skip_existing = TRUE`, the hole-filling and medial-wall fix lives in the surface-projection and label-classification stages, and those stages had cached output from an earlier build. The run logged "Loaded existing surface projection" and reproduced the same 1026/1075 unlabelled vertices. Only purging the cache by hand made the fix apply.

Caches were reused on `file.exists()` alone, so nothing could tell output written by the pipeline a fix _repaired_ from output written by the pipeline that _had_ the fix.

## What this does

A hand-bumped `cache_format_version()` is stamped into a `cache_manifest.rds` sidecar in each step directory, mapping cache name to the version that wrote it, and checked when caches are reused:

- **Stale, and the step was requested** — recompute, with a notice saying so. Since `steps` defaults to all steps, the ordinary "rerun the build after upgrading" case just works.
- **Stale, and the step was not requested** — abort naming the step, the files, both version numbers and the remedy. The alternatives are using known-wrong data or silently running work the user explicitly excluded.

Covered: the `.rds` step caches, the contour `.rda` files, and the processed-image and mask directories. Not covered, and named as such in one canonical place: the snapshot PNGs, the subcortical mesh directory, and the lookup table and volume the wholebrain pipeline hands to the subcortical one.

## Design notes

- **A hand-bumped constant, not a hash.** The failure was a _pipeline_ change with identical inputs, so input hashing would not have caught it, and hashing the pipeline source would invalidate every cache on every unrelated commit. Deriving the stamp from the package dev version was considered and rejected for the same reason: this repo bumps `.900X` on every PR, so every atlas maintainer's cache would die on changes that cannot affect it, at hours of FreeSurfer time each. A hand-bumped constant puts the cost where the judgement is. The rule is documented in `.github/copilot-instructions.md` next to the existing version-bump rule. Nothing detects a forgotten bump — see the follow-ups below.
- **A sidecar, not an attribute or a column.** Attributes do not survive the dplyr verbs the pipelines apply to loaded data — that is exactly why #138 had to smuggle its `y_axis` marker in as a column. One manifest covers `.rds`, `.rda` and whole directories without changing any cached object's shape.
- **Atomic manifest writes.** These builds run for hours and are routinely interrupted. Truncating in place meant a Ctrl-C mid-write could lose every stamp in the directory and turn the next partial rerun into a spurious abort, so the manifest is staged beside its target and renamed in.
- **Directory stamping happens after the parallel workers join**, in `run_image_steps()`, which is the single point that both produces the images and consumes them. `stamp_cache_files()` is documented as main-thread-only: the atomic rename protects against a torn manifest, not against two workers dropping each other's rows.
- **`check_contour_y_axis()` from #138 is kept** alongside the general check. It asserts a property the downstream code depends on, rather than the provenance of the file carrying it.

## Behaviour for an existing atlas repo

Every pre-1.9.9.9024 cache is unstamped, so it reads as stale. A normal full rebuild recomputes the affected stages, logging e.g. `Step 1 (Project to surface): cached output predates this ggseg.extra; recomputing.` A run with restricted `steps` that excludes a stale step aborts:

```
Error: Cached 'data-raw/miccai/atlas_data.rds' was written by cache format none.
i This ggseg.extra writes cache format 1.
i Include step 1 in the steps argument to rebuild it; steps whose cache is
  current are still reused.
```

## Test Plan

- [x] Full suite: 2441 tests, 0 failures / errors / skips / warnings (2421 on main).
- [x] `devtools::check(document = FALSE)`: 0 errors, 0 warnings, 1 NOTE (`.git`, a worktree artefact).
- [x] Traced against the real #142 failure: whole-brain defaults to `steps = 1:5`, so pre-#137 caches for `atlas_data.rds`/`colortable.rds`/`label_split.rds` now recompute instead of loading; the nested cortical pipeline recomputes `atlas_3d.rds`/`components.rds` too.
- [x] All three `load_or_run_step()` branches exercised against real files; corrupt-manifest → everything-stale pinned; stale contour and mask caches abort; directories stamped after processing.
- [x] `air format`; lintr (CI set) at the pre-existing baseline.
- [x] Confirmed the manifest cannot be picked up by the directory scans that look for regions and images: those scan subdirectories, and the two scans that lacked a file pattern now have one.

## Follow-ups, deliberately not in this PR

- Give the contour steps the same step gate the `.rds` steps have, absorbing the three hand-rolled "requires contours_reduced.rda" aborts in `R/atlas_tracts.R` and `R/atlas_subcortical.R`. That is the destination this sidecar is a step toward.
- Cover `dirs$meshes`, which means stamping inside a parallel producer — the one thing `stamp_cache_files()` is documented as unsafe for.
- A CI guard for a forgotten version bump. Skipped here: every workflow in this repo is a thin caller of `ggsegverse/.github`, and a "pipeline files changed without `R/cache_version.R`" heuristic would fire on nearly every PR and train reviewers to dismiss it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
